### PR TITLE
Adding Serializer abstraction and implementation, Logging abstraction and Type to create Retrofit based clients

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -21,6 +21,12 @@ allprojects {
 
     ext {
         okHttpVersion = "4.2.2"
+        retrofitVersion = "2.6.2"
+        jacksonDatabindVersion = "2.9.9"
+        jacksonDataFormatXmlVersion = "2.9.9"
+        staxApiVersion = "1.0-2"
+        threetenbpVersion = "1.4.0"
+        slf4jAndroidVersion = "1.7.29"
     }
 }
 

--- a/sdk/core/azure-core/build.gradle
+++ b/sdk/core/azure-core/build.gradle
@@ -35,4 +35,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
+    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonDataFormatXmlVersion"
+    // Fixes: java.lang.NoClassDefFoundError: Failed resolution of: Ljavax/xml/stream/XMLInputFactory
+    // (https://stackoverflow.com/a/47371517/1473510)
+    implementation "javax.xml.stream:stax-api:$staxApiVersion"
+    implementation "org.threeten:threetenbp:$threetenbpVersion"
+    implementation "org.slf4j:slf4j-android:$slf4jAndroidVersion"
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/HeaderCollection.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/HeaderCollection.java
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation on a deserialized header type that indicates that the property should
+ * be treated as a header collection with the provided prefix.
+ */
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface HeaderCollection {
+    /**
+     * The header collection prefix.
+     *
+     * @return The header collection prefix
+     */
+    String value();
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/JsonFlatten.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/JsonFlatten.java
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.annotation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used for flattening properties separated by '.'.
+ * E.g. a property with JsonProperty value "properties.value"
+ * will have "value" property under the "properties" tree on
+ * the wire.
+ *
+ */
+@Retention(RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+public @interface JsonFlatten {
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/TypeUtil.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/TypeUtil.java
@@ -1,0 +1,203 @@
+package com.azure.android.core.implementation;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility type exposing methods to deal with {@link Type}.
+ */
+public final class TypeUtil {
+    /**
+     * Find all super classes including provided class.
+     *
+     * @param clazz the raw class to find super types for
+     * @return the list of super classes
+     */
+    public static List<Class<?>> getAllClasses(Class<?> clazz) {
+        List<Class<?>> types = new ArrayList<>();
+        while (clazz != null) {
+            types.add(clazz);
+            clazz = clazz.getSuperclass();
+        }
+        return types;
+    }
+
+    /**
+     * Get the generic arguments for a type.
+     *
+     * @param type the type to get arguments
+     * @return the generic arguments, empty if type is not parameterized
+     */
+    public static Type[] getTypeArguments(Type type) {
+        if (!(type instanceof ParameterizedType)) {
+            return new Type[0];
+        }
+        return ((ParameterizedType) type).getActualTypeArguments();
+    }
+
+    /**
+     * Get the generic argument, or the first if the type has more than one.
+     *
+     * @param type the type to get arguments
+     * @return the generic argument, null if type is not parameterized
+     */
+    public static Type getTypeArgument(Type type) {
+        if (!(type instanceof ParameterizedType)) {
+            return null;
+        }
+        return ((ParameterizedType) type).getActualTypeArguments()[0];
+    }
+
+    /**
+     * Get the raw class for a given type.
+     *
+     * @param type the input type
+     * @return the raw class
+     */
+    @SuppressWarnings("unchecked")
+    public static Class<?> getRawClass(Type type) {
+        if (type instanceof ParameterizedType) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        } else {
+            return (Class<?>) type;
+        }
+    }
+
+    /**
+     * Get the super type for a given type.
+     *
+     * @param type the input type
+     * @return the direct super type
+     */
+    public static Type getSuperType(Type type) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type genericSuperClass = ((Class<?>) parameterizedType.getRawType()).getGenericSuperclass();
+            if (genericSuperClass instanceof ParameterizedType) {
+                /*
+                 * Find erased generic types for the super class and replace
+                 * with actual type arguments from the parameterized type
+                 */
+                Type[] superTypeArguments = getTypeArguments(genericSuperClass);
+                List<Type> typeParameters =
+                    Arrays.asList(((Class<?>) parameterizedType.getRawType()).getTypeParameters());
+                int j = 0;
+                for (int i = 0; i != superTypeArguments.length; i++) {
+                    if (typeParameters.contains(superTypeArguments[i])) {
+                        superTypeArguments[i] = parameterizedType.getActualTypeArguments()[j++];
+                    }
+                }
+                return new ParameterizedType() {
+                    @Override
+                    public Type[] getActualTypeArguments() {
+                        return superTypeArguments;
+                    }
+
+                    @Override
+                    public Type getRawType() {
+                        return ((ParameterizedType) genericSuperClass).getRawType();
+                    }
+
+                    @Override
+                    public Type getOwnerType() {
+                        return null;
+                    }
+                };
+            } else {
+                return genericSuperClass;
+            }
+        } else {
+            return ((Class<?>) type).getGenericSuperclass();
+        }
+    }
+
+    /**
+     * Get the super type for a type in its super type chain, which has
+     * a raw class that matches the specified class.
+     *
+     * @param subType the sub type to find super type for
+     * @param rawSuperType the raw class for the super type
+     * @return the super type that matches the requirement
+     */
+    public static Type getSuperType(Type subType, Class<?> rawSuperType) {
+        while (subType != null && getRawClass(subType) != rawSuperType) {
+            subType = getSuperType(subType);
+        }
+        return subType;
+    }
+
+    /**
+     * Determines if a type is the same or a subtype for another type.
+     *
+     * @param subType the supposed sub type
+     * @param superType the supposed super type
+     * @return true if the first type is the same or a subtype for the second type
+     */
+    public static boolean isTypeOrSubTypeOf(Type subType, Type superType) {
+        Class<?> sub = getRawClass(subType);
+        Class<?> sup = getRawClass(superType);
+
+        return sup.isAssignableFrom(sub);
+    }
+
+    /**
+     * Create a parameterized type from a raw class and its type arguments.
+     *
+     * @param rawClass the raw class to construct the parameterized type
+     * @param genericTypes the generic arguments
+     * @return the parameterized type
+     */
+    public static ParameterizedType createParameterizedType(Class<?> rawClass, Type... genericTypes) {
+        return new ParameterizedType() {
+            @Override
+            public Type[] getActualTypeArguments() {
+                return genericTypes;
+            }
+
+            @Override
+            public Type getRawType() {
+                return rawClass;
+            }
+
+            @Override
+            public Type getOwnerType() {
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Returns whether the rest response expects to have any body (by checking if the body parameter type is set to
+     * Void, in which case no body is expected).
+     *
+     * @param restResponseReturnType The RestResponse subtype containing the type arguments we are inspecting.
+     * @return True if a body is expected, false if a Void body is expected.
+     */
+    public static boolean restResponseTypeExpectsBody(ParameterizedType restResponseReturnType) {
+        return getRestResponseBodyType(restResponseReturnType) != Void.class;
+    }
+
+    /**
+     * Returns the body type expected in the rest response.
+     *
+     * @param restResponseReturnType The RestResponse subtype containing the type arguments we are inspecting.
+     * @return The type of the body.
+     */
+    public static Type getRestResponseBodyType(Type restResponseReturnType) {
+        // if this type has type arguments, then we look at the last one to determine if it expects a body
+        final Type[] restResponseTypeArguments = TypeUtil.getTypeArguments(restResponseReturnType);
+        if (restResponseTypeArguments != null && restResponseTypeArguments.length > 0) {
+            return restResponseTypeArguments[restResponseTypeArguments.length - 1];
+        } else {
+            // no generic type on this RestResponse sub-type, so we go up to parent
+            return getRestResponseBodyType(TypeUtil.getSuperType(restResponseReturnType));
+        }
+    }
+
+    // Private Ctr
+    private TypeUtil() {
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/http/rest/RetrofitAPIClient.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/http/rest/RetrofitAPIClient.java
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.implementation.http.rest;
+
+import com.azure.android.core.util.serializer.JacksonAdapter;
+import com.azure.android.core.util.serializer.SerializerAdapter;
+import com.azure.android.core.util.serializer.SerializerEncoding;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Converter;
+import retrofit2.Retrofit;
+
+/**
+ * Type to create Retrofit based service-interface implementation.
+ */
+public class RetrofitAPIClient {
+    /**
+     * Create a Retrofit based API client implementation for a given service-interface.
+     *
+     * Note: anuchan: This method takes minimal parameters needed to create service-interface
+     * implementation, when needed we can add overloads that takes custom
+     * SerializerAdapter, OkHttpClient, which is needed when we enable user to provide
+     * an existing OkHttpClient with SSL/Proxy/SocketPool etc.. configured.
+     *
+     * @param baseUri the base uri to to use for service-interface method calls
+     * @param encoding the http content-type for request-response associated with the
+     *                 service-interface method calls
+     * @param interceptors the interceptors to intercept request-response associated with the
+     *                     service-interface method calls
+     * @param serviceInterface the service interface class
+     * @param <T> the type of the service-interface
+     * @return a (proxy based) implementation for the service-interface
+     */
+    public static <T> T createAPIClient(String baseUri,
+                                        SerializerEncoding encoding,
+                                        List<Interceptor> interceptors,
+                                        Class<T> serviceInterface) {
+        return createRetrofit(baseUri,
+                encoding,
+                JacksonAdapter.createDefaultSerializerAdapter(),
+                interceptors,
+                new OkHttpClient.Builder().build()).create(serviceInterface);
+    }
+
+    /**
+     * Creates a Retrofit instance that can be used to create proxies for service interface.
+     *
+     * @param baseUri the base uri
+     * @param encoding the http content-type for request-response
+     * @param serializerAdapter the serializer-deserializer for request-response content
+     * @param interceptors the interceptors to intercept request-response
+     * @param httpClient the OkHttpClient for network calls
+     * @return the Retrofit instance
+     */
+    private static Retrofit createRetrofit(String baseUri,
+                                           SerializerEncoding encoding,
+                                           SerializerAdapter serializerAdapter,
+                                           List<Interceptor> interceptors,
+                                           OkHttpClient httpClient) {
+        OkHttpClient.Builder builder = httpClient.newBuilder();
+        for (Interceptor interceptor : interceptors) {
+            builder.addInterceptor(interceptor);
+        }
+        return new Retrofit.Builder()
+                .baseUrl(baseUri)
+                .addConverterFactory(wrapSerializerInRetrofitConverter(serializerAdapter,
+                        encoding))
+                .callFactory(builder.build())
+                .build();
+    }
+
+    /**
+     * Given azure-core SerializerAdapter, wrap that in Retrofit Converter so that it can be
+     * plugged into Retrofit serialization-deserialization pipeline.
+     *
+     * @param serializer azure-core Serializer adapter
+     * @param encoding the encoding format
+     * @return Retrofit Converter
+     */
+    private static Converter.Factory wrapSerializerInRetrofitConverter(SerializerAdapter serializer,
+                                                                       final SerializerEncoding encoding) {
+        final MediaType mediaType = encoding == SerializerEncoding.XML
+                ? MediaType.parse("application/xml; charset=UTF-8")
+                : MediaType.parse("application/json; charset=UTF-8");
+        return new Converter.Factory() {
+            @Override
+            public Converter<?, RequestBody> requestBodyConverter(Type type,
+                                                                  Annotation[] parameterAnnotations,
+                                                                  Annotation[] methodAnnotations,
+                                                                  Retrofit retrofit) {
+                return value -> RequestBody.create(serializer.serialize(value, encoding), mediaType);
+            }
+
+            @Override
+            public Converter<ResponseBody, ?> responseBodyConverter(Type type,
+                                                                    Annotation[] annotations,
+                                                                    Retrofit retrofit) {
+                return (Converter<ResponseBody, Object>) body -> serializer.deserialize(body.string(),
+                        type,
+                        encoding);
+            }
+        };
+    }
+
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Url.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Url.java
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Encodes and decodes using Base64 URL encoding.
+ */
+public final class Base64Url {
+    /**
+     * The Base64Url encoded bytes.
+     */
+    private final byte[] bytes;
+
+    /**
+     * Creates a new Base64Url object with the specified encoded string.
+     *
+     * @param string The encoded string.
+     */
+    public Base64Url(String string) {
+        if (string == null) {
+            this.bytes = null;
+        } else {
+            string = unquote(string);
+            this.bytes = string.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Creates a new Base64Url object with the specified encoded bytes.
+     *
+     * @param bytes The encoded bytes.
+     */
+    public Base64Url(byte[] bytes) {
+        this.bytes = unquote(bytes);
+    }
+
+    private static byte[] unquote(byte[] bytes) {
+        if (bytes != null && bytes.length > 1) {
+            bytes = unquote(new String(bytes, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8);
+        }
+        return bytes;
+    }
+
+    private static String unquote(String string) {
+        if (string != null && !string.isEmpty()) {
+            final char firstCharacter = string.charAt(0);
+            if (firstCharacter == '\"' || firstCharacter == '\'') {
+                final int base64UrlStringLength = string.length();
+                final char lastCharacter = string.charAt(base64UrlStringLength - 1);
+                if (lastCharacter == firstCharacter) {
+                    string = string.substring(1, base64UrlStringLength - 1);
+                }
+            }
+        }
+        return string;
+    }
+
+    /**
+     * Encodes a byte array into Base64Url encoded bytes.
+     *
+     * @param bytes The byte array to encode.
+     * @return A new Base64Url instance.
+     */
+    public static Base64Url encode(byte[] bytes) {
+        if (bytes == null) {
+            return new Base64Url((String) null);
+        } else {
+            return new Base64Url(Base64Util.encodeURLWithoutPadding(bytes));
+        }
+    }
+
+    /**
+     * Returns the underlying encoded byte array.
+     *
+     * @return The underlying encoded byte array.
+     */
+    public byte[] encodedBytes() {
+        return CoreUtils.clone(bytes);
+    }
+
+    /**
+     * Decode the bytes and returns its value.
+     *
+     * @return The decoded byte array.
+     */
+    public byte[] decodedBytes() {
+        if (this.bytes == null) {
+            return null;
+        }
+
+        return Base64Util.decodeURL(bytes);
+    }
+
+    @Override
+    public String toString() {
+        return bytes == null ? "" : new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (!(obj instanceof Base64Url)) {
+            return false;
+        }
+
+        Base64Url rhs = (Base64Url) obj;
+        return Arrays.equals(this.bytes, rhs.encodedBytes());
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Util.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Util.java
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util;
+
+import android.util.Base64;
+
+/**
+ * Utility type exposing Base64 encoding and decoding methods.
+ */
+public final class Base64Util {
+    /**
+     * Encodes a byte array to base64.
+     * @param src the byte array to encode
+     * @return the base64 encoded bytes
+     */
+    public static byte[] encode(byte[] src) {
+        return src == null ? null : Base64.encode(src, Base64.DEFAULT);
+    }
+
+    /**
+     * Encodes a byte array to base64 URL format.
+     * @param src the byte array to encode
+     * @return the base64 URL encoded bytes
+     */
+    public static byte[] encodeURLWithoutPadding(byte[] src) {
+        int flags = Base64.URL_SAFE | Base64.NO_PADDING;
+        return src == null ? null : Base64.encode(src, flags);
+    }
+
+    /**
+     * Encodes a byte array to a base 64 string.
+     * @param src the byte array to encode
+     * @return the base64 encoded string
+     */
+    public static String encodeToString(byte[] src) {
+        return src == null ? null : Base64.encodeToString(src, Base64.DEFAULT);
+    }
+
+    /**
+     * Decodes a base64 encoded byte array.
+     * @param encoded the byte array to decode
+     * @return the decoded byte array
+     */
+    public static byte[] decode(byte[] encoded) {
+        return encoded == null ? null : Base64.decode(encoded, Base64.DEFAULT);
+    }
+
+    /**
+     * Decodes a byte array in base64 URL format.
+     * @param src the byte array to decode
+     * @return the decoded byte array
+     */
+    public static byte[] decodeURL(byte[] src) {
+        return src == null ? null : Base64.decode(src, Base64.URL_SAFE);
+    }
+
+    /**
+     * Decodes a base64 encoded string.
+     * @param encoded the string to decode
+     * @return the decoded byte array
+     */
+    public static byte[] decodeString(String encoded) {
+        return encoded == null ? null : Base64.decode(encoded, Base64.DEFAULT);
+    }
+
+    // Private Ctr
+    private Base64Util() {
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/CoreUtils.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/CoreUtils.java
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util;
+
+import android.text.TextUtils;
+
+import com.azure.android.core.util.function.Function;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * This class contains utility methods useful for building client libraries.
+ */
+public final class CoreUtils {
+    private static final String COMMA = ",";
+
+    private CoreUtils() {
+        // Exists only to defeat instantiation.
+    }
+
+    /**
+     * Creates a copy of the source byte array.
+     * @param source Array to make copy of
+     * @return A copy of the array, or null if source was null.
+     */
+    public static byte[] clone(byte[] source) {
+        if (source == null) {
+            return null;
+        }
+        byte[] copy = new byte[source.length];
+        System.arraycopy(source, 0, copy, 0, source.length);
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the source int array.
+     * @param source Array to make copy of
+     * @return A copy of the array, or null if source was null.
+     */
+    public static int[] clone(int[] source) {
+        if (source == null) {
+            return null;
+        }
+        int[] copy = new int[source.length];
+        System.arraycopy(source, 0, copy, 0, source.length);
+        return copy;
+    }
+
+    /**
+     * Creates a copy of the source array.
+     * @param source Array being copied.
+     * @param <T> Generic representing the type of the source array.
+     * @return A copy of the array or null if source was null.
+     */
+    public static <T> T[] clone(T[] source) {
+        if (source == null) {
+            return null;
+        }
+
+        return Arrays.copyOf(source, source.length);
+    }
+
+    /**
+     * Checks if the array is null or empty.
+     * @param array Array being checked for nullness or emptiness.
+     * @return True if the array is null or empty, false otherwise.
+     */
+    public static boolean isNullOrEmpty(Object[] array) {
+        return array == null || array.length == 0;
+    }
+
+    /**
+     * Checks if the collection is null or empty.
+     * @param collection Collection being checked for nullness or emptiness.
+     * @return True if the collection is null or empty, false otherwise.
+     */
+    public static boolean isNullOrEmpty(Collection<?> collection) {
+        return collection == null || collection.isEmpty();
+    }
+
+    /**
+     * Checks if the map is null or empty.
+     * @param map Map being checked for nullness or emptiness.
+     * @return True if the map is null or empty, false otherwise.
+     */
+    public static boolean isNullOrEmpty(Map<?, ?> map) {
+        return map == null || map.isEmpty();
+    }
+
+    /**
+     * Checks if the character sequence is null or empty.
+     * @param charSequence Character sequence being checked for nullness or emptiness.
+     * @return True if the character sequence is null or empty, false otherwise.
+     */
+    public static boolean isNullOrEmpty(CharSequence charSequence) {
+        return charSequence == null || charSequence.length() == 0;
+    }
+
+    /**
+     * Turns an array into a string mapping each element to a string and delimits them using a coma.
+     * @param array Array being formatted to a string.
+     * @param mapper Function that maps each element to a string.
+     * @param <T> Generic representing the type of the array.
+     * @return Array with each element mapped and delimited, otherwise null if the array is empty or null.
+     */
+    public static <T> String arrayToString(T[] array, Function<T, String> mapper) {
+        if (isNullOrEmpty(array)) {
+            return null;
+        }
+
+        String [] mappedArray = new String[array.length];
+        int i = 0;
+        for (T item : array) {
+            mappedArray[i] = mapper.apply(item);
+            i++;
+        }
+        return TextUtils.join(COMMA, mappedArray);
+    }
+
+    /**
+     * Returns the first instance of the given class from an array of Objects.
+     * @param args Array of objects to search through to find the first instance of the given `clazz` type.
+     * @param clazz The type trying to be found.
+     * @param <T> Generic type
+     * @return The first object of the desired type, otherwise null.
+     */
+    public static <T> T findFirstOfType(Object[] args, Class<T> clazz) {
+        if (isNullOrEmpty(args)) {
+            return null;
+        }
+
+        for (Object arg : args) {
+            if (clazz.isInstance(arg)) {
+                return clazz.cast(arg);
+            }
+        }
+
+        return null;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/DateTimeRfc1123.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/DateTimeRfc1123.java
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Wrapper over java.util.Date used for specifying RFC1123 format during serialization and deserialization.
+ */
+public final class DateTimeRfc1123 {
+
+    private static final String RFC1123_DATE_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
+
+    /**
+     * The actual Date object.
+     */
+    private final Date dateTime;
+
+    /**
+     * Creates a new DateTimeRfc1123 object with the specified DateTime.
+     * @param dateTime The Date object to wrap.
+     */
+    public DateTimeRfc1123(Date dateTime) {
+        this.dateTime = dateTime;
+    }
+
+    /**
+     * Creates a new DateTimeRfc1123 object with the specified DateTime.
+     * @param formattedString The Date string in RFC1123 format
+     */
+    public DateTimeRfc1123(String formattedString) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(RFC1123_DATE_TIME_FORMAT, Locale.US);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        try {
+            this.dateTime = dateFormat.parse(formattedString);
+        } catch (ParseException pe) {
+            throw new RuntimeException(pe);
+        }
+    }
+
+    /**
+     * Returns the underlying Date.
+     * @return The underlying Date.
+     */
+    public Date dateTime() {
+        if (this.dateTime == null) {
+            return null;
+        }
+        return this.dateTime;
+    }
+
+    @Override
+    public String toString() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat(RFC1123_DATE_TIME_FORMAT, Locale.US);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.format(this.dateTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.dateTime.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (!(obj instanceof DateTimeRfc1123)) {
+            return false;
+        }
+
+        DateTimeRfc1123 rhs = (DateTimeRfc1123) obj;
+        return this.dateTime.equals(rhs.dateTime());
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/function/Function.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/function/Function.java
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.function;
+
+public interface Function<T, R> {
+    R apply(T t);
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/logging/ClientLogger.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/logging/ClientLogger.java
@@ -1,0 +1,281 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.logging;
+
+import com.azure.android.core.util.CoreUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * This is a fluent logger helper class that wraps a pluggable {@link Logger}.
+ *
+ * <p>This logger logs formattable messages that use {@code {}} as the placeholder. When a {@link Throwable throwable}
+ * is the last argument of the format varargs and the logger is enabled for
+ * {@link ClientLogger#verbose(String, Object...) verbose}, the stack trace for the throwable is logged.</p>
+ *
+ * <p><strong>Log level hierarchy</strong></p>
+ * <ol>
+ * <li>{@link ClientLogger#error(String, Object...) Error}</li>
+ * <li>{@link ClientLogger#warning(String, Object...) Warning}</li>
+ * <li>{@link ClientLogger#info(String, Object...) Info}</li>
+ * <li>{@link ClientLogger#verbose(String, Object...) Verbose}</li>
+ * </ol>
+ *
+ */
+public class ClientLogger {
+    private final Logger logger;
+
+    /*
+     * Indicates that log level is at verbose level.
+     */
+    private static final int VERBOSE_LEVEL = 1;
+
+    /*
+     * Indicates that log level is at information level.
+     */
+    private static final int INFORMATIONAL_LEVEL = 2;
+
+    /*
+     * Indicates that log level is at warning level.
+     */
+    private static final int WARNING_LEVEL = 3;
+
+    /*
+     * Indicates that log level is at error level.
+     */
+    private static final int ERROR_LEVEL = 4;
+
+    /*
+     * Indicates that logging is disabled.
+     */
+    private static final int DISABLED_LEVEL = 5;
+
+    /**
+     * Retrieves a logger for the passed class using the {@link LoggerFactory}.
+     *
+     * @param clazz Class creating the logger.
+     */
+    public ClientLogger(Class<?> clazz) {
+        this(clazz.getName());
+    }
+
+    /**
+     * Retrieves a logger for the passed class name using the {@link LoggerFactory}.
+     *
+     * @param className Class name creating the logger.
+     */
+    public ClientLogger(String className) {
+        logger = LoggerFactory.getLogger(className);
+    }
+
+    /**
+     * Logs a formattable message that uses {@code {}} as the placeholder at {@code verbose} log level.
+     *
+     * <p><strong>Code samples</strong></p>
+     *
+     * <p>Logging a message at verbose log level.</p>
+     *
+     * {@codesnippet com.azure.core.util.logging.clientlogger.verbose}
+     *
+     * @param format The formattable message to log.
+     * @param args Arguments for the message. If an exception is being logged, the last argument should be the
+     *     {@link Throwable}.
+     */
+    public void verbose(String format, Object... args) {
+        log(VERBOSE_LEVEL, format, args);
+    }
+
+    /**
+     * Logs a formattable message that uses {@code {}} as the placeholder at {@code informational} log level.
+     *
+     * <p><strong>Code samples</strong></p>
+     *
+     * <p>Logging a message at informational log level.</p>
+     *
+     * {@codesnippet com.azure.core.util.logging.clientlogger.info}
+     *
+     * @param format The formattable message to log
+     * @param args Arguments for the message. If an exception is being logged, the last argument should be the
+     *     {@link Throwable}.
+     */
+    public void info(String format, Object... args) {
+        log(INFORMATIONAL_LEVEL, format, args);
+    }
+
+    /**
+     * Logs a formattable message that uses {@code {}} as the placeholder at {@code warning} log level.
+     *
+     * <p><strong>Code samples</strong></p>
+     *
+     * <p>Logging a message at warning log level.</p>
+     *
+     * {@codesnippet com.azure.core.util.logging.clientlogger.warning}
+     *
+     * @param format The formattable message to log.
+     * @param args Arguments for the message. If an exception is being logged, the last argument should be the
+     *     {@link Throwable}.
+     */
+    public void warning(String format, Object... args) {
+        log(WARNING_LEVEL, format, args);
+    }
+
+    /**
+     * Logs a formattable message that uses {@code {}} as the placeholder at {@code error} log level.
+     *
+     * <p><strong>Code samples</strong></p>
+     *
+     * <p>Logging an error with stack trace.</p>
+     *
+     * {@codesnippet com.azure.core.util.logging.clientlogger.error}
+     *
+     * @param format The formattable message to log.
+     * @param args Arguments for the message. If an exception is being logged, the last argument should be the
+     *     {@link Throwable}.
+     */
+    public void error(String format, Object... args) {
+        log(ERROR_LEVEL, format, args);
+    }
+
+    /*
+     * This method logs the formattable message if the {@code logLevel} is enabled
+     *
+     * @param logLevel The log level at which this message should be logged
+     * @param format The formattable message to log
+     * @param args Arguments for the message, if an exception is being logged last argument is the throwable.
+     */
+    private void log(int logLevel, String format, Object... args) {
+        if (canLogAtLevel(logLevel)) {
+            performLogging(logLevel, false, format, args);
+        }
+    }
+
+    /**
+     * Logs the {@link RuntimeException} at the warning level and returns it to be thrown.
+     *
+     * @param runtimeException RuntimeException to be logged and returned.
+     * @return The passed {@code RuntimeException}.
+     * @throws NullPointerException If {@code runtimeException} is {@code null}.
+     */
+    public RuntimeException logExceptionAsWarning(RuntimeException runtimeException) {
+        return logException(runtimeException, WARNING_LEVEL);
+    }
+
+    /**
+     * Logs the {@link RuntimeException} at the error level and returns it to be thrown.
+     *
+     * @param runtimeException RuntimeException to be logged and returned.
+     * @return The passed {@code RuntimeException}.
+     * @throws NullPointerException If {@code runtimeException} is {@code null}.
+     */
+    public RuntimeException logExceptionAsError(RuntimeException runtimeException) {
+        return logException(runtimeException, ERROR_LEVEL);
+    }
+
+    private RuntimeException logException(RuntimeException runtimeException, int logLevel) {
+        Objects.requireNonNull(runtimeException, "'runtimeException' cannot be null.");
+
+        if (canLogAtLevel(logLevel)) {
+            performLogging(logLevel, true, runtimeException.getMessage(), runtimeException);
+        }
+
+        return runtimeException;
+    }
+
+    /*
+     * Performs the logging.
+     *
+     * @param format formattable message.
+     * @param args Arguments for the message, if an exception is being logged last argument is the throwable.
+     */
+    private void performLogging(int logLevel, boolean isExceptionLogging, String format,
+        Object... args) {
+        // If the logging level is less granular than verbose remove the potential throwable from the args.
+        String throwableMessage = "";
+        if (doesArgsHaveThrowable(args)) {
+            // If we are logging an exception the format string is already the exception message, don't append it.
+            if (!isExceptionLogging) {
+                Object throwable = args[args.length - 1];
+
+                // This is true from before but is needed to appease SpotBugs.
+                if (throwable instanceof Throwable) {
+                    throwableMessage = ((Throwable) throwable).getMessage();
+                }
+            }
+        }
+
+        switch (logLevel) {
+            case VERBOSE_LEVEL:
+                logger.debug(format, args);
+                break;
+            case INFORMATIONAL_LEVEL:
+                logger.info(format, args);
+                break;
+            case WARNING_LEVEL:
+                if (!CoreUtils.isNullOrEmpty(throwableMessage)) {
+                    format += System.lineSeparator() + throwableMessage;
+                }
+                logger.warn(format, args);
+                break;
+            case ERROR_LEVEL:
+                if (!CoreUtils.isNullOrEmpty(throwableMessage)) {
+                    format += System.lineSeparator() + throwableMessage;
+                }
+                logger.error(format, args);
+                break;
+            default:
+                // Don't do anything, this state shouldn't be possible.
+                break;
+        }
+    }
+
+    /*
+     * Determines if the environment and logger support logging at the given log level.
+     *
+     * @param logLevel Logging level for the log message.
+     * @return Flag indicating if the environment and logger are configured to support logging at the given log level.
+     */
+    private boolean canLogAtLevel(int logLevel) {
+        // Determine if the logger configuration supports logging at the level.
+        switch (logLevel) {
+            case VERBOSE_LEVEL:
+                return logger.isDebugEnabled();
+            case INFORMATIONAL_LEVEL:
+                return logger.isInfoEnabled();
+            case WARNING_LEVEL:
+                return logger.isWarnEnabled();
+            case ERROR_LEVEL:
+                return logger.isErrorEnabled();
+            default:
+                return false;
+        }
+    }
+
+    /*
+     * Determines if the arguments contains a throwable that would be logged, SLF4J logs a throwable if it is the last
+     * element in the argument list.
+     *
+     * @param args The arguments passed to format the log message.
+     * @return True if the last element is a throwable, false otherwise.
+     */
+    private boolean doesArgsHaveThrowable(Object... args) {
+        if (args.length == 0) {
+            return false;
+        }
+
+        return args[args.length - 1] instanceof Throwable;
+    }
+
+    /*
+     * Removes the last element from the arguments as it is a throwable.
+     *
+     * @param args The arguments passed to format the log message.
+     * @return The arguments with the last element removed.
+     */
+    private Object[] removeThrowable(Object... args) {
+        return Arrays.copyOf(args, args.length - 1);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/AdditionalPropertiesDeserializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/AdditionalPropertiesDeserializer.java
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.azure.android.core.implementation.TypeUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+/**
+ * Custom serializer for deserializing complex types with additional properties.
+ * If a complex type has a property named "additionalProperties" with serialized
+ * name empty ("") of type Map&lt;String, Object&gt;, all extra properties on the
+ * payload will be stored in this map.
+ */
+final class AdditionalPropertiesDeserializer extends StdDeserializer<Object> implements ResolvableDeserializer {
+    private static final long serialVersionUID = 700052863615540646L;
+
+    /**
+     * The default mapperAdapter for the current type.
+     */
+    private final JsonDeserializer<?> defaultDeserializer;
+
+    /**
+     * The object mapper for default deserializations.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * Creates FlatteningDeserializer.
+     * @param vc handled type
+     * @param defaultDeserializer the default JSON mapperAdapter
+     * @param mapper the object mapper for default deserializations
+     */
+    protected AdditionalPropertiesDeserializer(Class<?> vc, JsonDeserializer<?> defaultDeserializer,
+                                               ObjectMapper mapper) {
+        super(vc);
+        this.defaultDeserializer = defaultDeserializer;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @param mapper the object mapper for default deserializations
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule(final ObjectMapper mapper) {
+        SimpleModule module = new SimpleModule();
+        module.setDeserializerModifier(new BeanDeserializerModifier() {
+            @Override
+            public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc,
+                                                          JsonDeserializer<?> deserializer) {
+                for (Class<?> c : TypeUtil.getAllClasses(beanDesc.getBeanClass())) {
+                    Field[] fields = c.getDeclaredFields();
+                    for (Field field : fields) {
+                        if ("additionalProperties".equalsIgnoreCase(field.getName())) {
+                            JsonProperty property = field.getAnnotation(JsonProperty.class);
+                            if (property != null && property.value().isEmpty()) {
+                                return new AdditionalPropertiesDeserializer(beanDesc.getBeanClass(), deserializer,
+                                    mapper);
+                            }
+                        }
+                    }
+                }
+                return deserializer;
+            }
+        });
+        return module;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        ObjectNode root = mapper.readTree(jp);
+        ObjectNode copy = root.deepCopy();
+
+        // compare top level fields and keep only missing fields
+        final Class<?> tClass = this.defaultDeserializer.handledType();
+        for (Class<?> c : TypeUtil.getAllClasses(tClass)) {
+            Field[] fields = c.getDeclaredFields();
+            for (Field field : fields) {
+                // JaCoCo adds synthetic fields for instrumentation.
+                // It's recommended to skip fields that are marked synthetic.
+                // https://www.eclemma.org/jacoco/trunk/doc/faq.html
+                // https://github.com/jacoco/jacoco/issues/168
+                if (field.isSynthetic()) {
+                    continue;
+                }
+                JsonProperty property = field.getAnnotation(JsonProperty.class);
+                String key = property.value().split("((?<!\\\\))\\.")[0];
+                if (!key.isEmpty()) {
+                    if (copy.has(key)) {
+                        copy.remove(key);
+                    }
+                }
+            }
+        }
+
+        // put into additional properties
+        root.put("additionalProperties", copy);
+
+        JsonParser parser = new JsonFactory().createParser(root.toString());
+        parser.nextToken();
+        return defaultDeserializer.deserialize(parser, ctxt);
+    }
+
+    @Override
+    public void resolve(DeserializationContext ctxt) throws JsonMappingException {
+        ((ResolvableDeserializer) defaultDeserializer).resolve(ctxt);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/AdditionalPropertiesSerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/AdditionalPropertiesSerializer.java
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.azure.android.core.implementation.TypeUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+/**
+ * Custom serializer for serializing complex types with additional properties.
+ * If a complex type has a property named "additionalProperties" with serialized
+ * name empty ("") of type Map&lt;String, Object&gt;, all items in this map will
+ * become top level properties for this complex type.
+ */
+final class AdditionalPropertiesSerializer extends StdSerializer<Object> implements ResolvableSerializer {
+    private static final long serialVersionUID = -3458779491516161716L;
+
+    /**
+     * The default mapperAdapter for the current type.
+     */
+    private final JsonSerializer<?> defaultSerializer;
+
+    /**
+     * The object mapper for default serializations.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * Creates an instance of FlatteningSerializer.
+     * @param vc handled type
+     * @param defaultSerializer the default JSON serializer
+     * @param mapper the object mapper for default serializations
+     */
+    protected AdditionalPropertiesSerializer(Class<?> vc, JsonSerializer<?> defaultSerializer, ObjectMapper mapper) {
+        super(vc, false);
+        this.defaultSerializer = defaultSerializer;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @param mapper the object mapper for default serializations
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule(final ObjectMapper mapper) {
+        SimpleModule module = new SimpleModule();
+        module.setSerializerModifier(new BeanSerializerModifier() {
+            @Override
+            public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc,
+                                                      JsonSerializer<?> serializer) {
+                for (Class<?> c : TypeUtil.getAllClasses(beanDesc.getBeanClass())) {
+                    if (c.isAssignableFrom(Object.class)) {
+                        continue;
+                    }
+                    Field[] fields = c.getDeclaredFields();
+                    for (Field field : fields) {
+                        if ("additionalProperties".equalsIgnoreCase(field.getName())) {
+                            JsonProperty property = field.getAnnotation(JsonProperty.class);
+                            if (property != null && property.value().isEmpty()) {
+                                return new AdditionalPropertiesSerializer(beanDesc.getBeanClass(), serializer, mapper);
+                            }
+                        }
+                    }
+                }
+                return serializer;
+            }
+        });
+        return module;
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        // serialize the original object into JsonNode
+        ObjectNode root = mapper.valueToTree(value);
+        // take additional properties node out
+        Entry<String, JsonNode> additionalPropertiesField = null;
+        Iterator<Entry<String, JsonNode>> fields = root.fields();
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> field = fields.next();
+            if ("additionalProperties".equalsIgnoreCase(field.getKey())) {
+                additionalPropertiesField = field;
+                break;
+            }
+        }
+        if (additionalPropertiesField != null) {
+            root.remove(additionalPropertiesField.getKey());
+            // put each item back in
+            ObjectNode extraProperties = (ObjectNode) additionalPropertiesField.getValue();
+            fields = extraProperties.fields();
+            while (fields.hasNext()) {
+                Entry<String, JsonNode> field = fields.next();
+                root.put(field.getKey(), field.getValue());
+            }
+        }
+
+        jgen.writeTree(root);
+    }
+
+    @Override
+    public void resolve(SerializerProvider provider) throws JsonMappingException {
+        ((ResolvableSerializer) defaultSerializer).resolve(provider);
+    }
+
+    @Override
+    public void serializeWithType(Object value, JsonGenerator gen, SerializerProvider provider,
+                                  TypeSerializer typeSerializer) throws IOException {
+        serialize(value, gen, provider);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/Base64UrlSerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/Base64UrlSerializer.java
@@ -1,0 +1,32 @@
+
+package com.azure.android.core.util.serializer;
+
+import com.azure.android.core.util.Base64Url;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for serializing {@code Byte[]} objects into Base64 strings.
+ */
+final class Base64UrlSerializer extends JsonSerializer<Base64Url> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Base64Url.class, new Base64UrlSerializer());
+        return module;
+    }
+
+    @Override
+    public void serialize(Base64Url value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeString(value.toString());
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/ByteArraySerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/ByteArraySerializer.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for serializing {@code Byte[]} objects into Base64 strings.
+ */
+final class ByteArraySerializer extends JsonSerializer<Byte[]> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Byte[].class, new ByteArraySerializer());
+        return module;
+    }
+
+    @Override
+    public void serialize(Byte[] value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        byte[] bytes = new byte[value.length];
+        for (int i = 0; i < value.length; i++) {
+            bytes[i] = value[i];
+        }
+        jgen.writeBinary(bytes);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/CollectionFormat.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/CollectionFormat.java
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+/**
+ * Swagger collection format to use for joining {@link java.util.List} parameters in
+ * paths, queries, and headers.
+ * See
+ * <a href="https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields-7">
+ *     https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields-7</a>.
+ */
+public enum CollectionFormat {
+    /**
+     * Comma separated values.
+     * E.g. foo,bar
+     */
+    CSV(","),
+    /**
+     * Space separated values.
+     * E.g. foo bar
+     */
+    SSV(" "),
+    /**
+     * Tab separated values.
+     * E.g. foo\tbar
+     */
+    TSV("\t"),
+    /**
+     * Pipe(|) separated values.
+     * E.g. foo|bar
+     */
+    PIPES("|"),
+    /**
+     * Corresponds to multiple parameter instances instead of multiple values
+     * for a single instance.
+     * E.g. foo=bar&amp;foo=baz
+     */
+    MULTI("&");
+
+    /**
+     * The delimiter separating the values.
+     */
+    private String delimiter;
+
+    /**
+     * Creates CollectionFormat enum.
+     *
+     * @param delimiter the delimiter as a string.
+     */
+    CollectionFormat(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    /**
+     * Gets the delimiter used to join a list of parameters.
+     *
+     * @return the delimiter of the current collection format.
+     */
+    public String getDelimiter() {
+        return delimiter;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/DateTimeRfc1123Serializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/DateTimeRfc1123Serializer.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.azure.android.core.util.DateTimeRfc1123;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for serializing {@link DateTimeRfc1123} object into RFC1123 formats.
+ */
+final class DateTimeRfc1123Serializer extends JsonSerializer<DateTimeRfc1123> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(DateTimeRfc1123.class, new DateTimeRfc1123Serializer());
+        return module;
+    }
+
+    @Override
+    public void serialize(DateTimeRfc1123 value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if (provider.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)) {
+            jgen.writeNumber(value.dateTime().getTime());
+        } else {
+            jgen.writeString(value.toString()); //Use the default toString as it is RFC1123.
+        }
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/DateTimeSerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/DateTimeSerializer.java
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.format.DateTimeFormatter;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for serializing {@link OffsetDateTime} object into ISO8601 formats.
+ */
+final class DateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(OffsetDateTime.class, new DateTimeSerializer());
+        return module;
+    }
+
+    @Override
+    public void serialize(OffsetDateTime value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if (provider.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)) {
+            jgen.writeNumber(value.toInstant().toEpochMilli());
+        } else {
+            jgen.writeString(toString(value));
+        }
+    }
+
+    /**
+     * Convert the provided OffsetDateTime to its String representation.
+     * @param offsetDateTime The OffsetDateTime to convert.
+     * @return The String representation of the provided offsetDateTime.
+     */
+    public static String toString(OffsetDateTime offsetDateTime) {
+        String result = null;
+        if (offsetDateTime != null) {
+            offsetDateTime = offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC);
+            result = DateTimeFormatter.ISO_INSTANT.format(offsetDateTime);
+            if (result.startsWith("+")) {
+                result = result.substring(1);
+            }
+        }
+        return result;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/DurationSerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/DurationSerializer.java
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+
+import org.threeten.bp.Duration;
+import org.threeten.bp.temporal.ChronoUnit;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer for serializing {@link Duration} object into ISO8601 formats.
+ */
+final class DurationSerializer extends JsonSerializer<Duration> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Duration.class, new DurationSerializer());
+        return module;
+    }
+
+    @Override
+    public void serialize(Duration duration, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+        throws IOException {
+        jsonGenerator.writeString(DurationSerializer.toString(duration));
+    }
+
+    /**
+     * Convert to provided Duration to an ISO 8601 String with a days component.
+     * @param duration The Duration to convert.
+     * @return The String representation of the provided Duration.
+     */
+    public static String toString(Duration duration) {
+        String result = null;
+        if (duration != null) {
+            if (duration.get(ChronoUnit.MILLIS) == 0) {
+                result = "PT0S";
+            } else {
+                final StringBuilder builder = new StringBuilder();
+
+                builder.append('P');
+
+                final long days = duration.get(ChronoUnit.DAYS);
+                if (days > 0) {
+                    builder.append(days);
+                    builder.append('D');
+                    duration = duration.minusDays(days);
+                }
+
+                final long hours = duration.get(ChronoUnit.HOURS);
+                if (hours > 0) {
+                    builder.append('T');
+                    builder.append(hours);
+                    builder.append('H');
+                    duration = duration.minusHours(hours);
+                }
+
+                final long minutes = duration.get(ChronoUnit.MINUTES);
+                if (minutes > 0) {
+                    if (hours == 0) {
+                        builder.append('T');
+                    }
+
+                    builder.append(minutes);
+                    builder.append('M');
+                    duration = duration.minusMinutes(minutes);
+                }
+
+                final long seconds = duration.get(ChronoUnit.SECONDS);
+                if (seconds > 0) {
+                    if (hours == 0 && minutes == 0) {
+                        builder.append('T');
+                    }
+
+                    builder.append(seconds);
+                    duration = duration.minusSeconds(seconds);
+                }
+
+                long milliseconds = duration.get(ChronoUnit.MILLIS);
+                if (milliseconds > 0) {
+                    if (hours == 0 && minutes == 0 && seconds == 0) {
+                        builder.append("T");
+                    }
+
+                    if (seconds == 0) {
+                        builder.append("0");
+                    }
+
+                    builder.append('.');
+
+                    if (milliseconds <= 99) {
+                        builder.append('0');
+
+                        if (milliseconds <= 9) {
+                            builder.append('0');
+                        }
+                    }
+
+                    // Remove trailing zeros.
+                    while (milliseconds % 10 == 0) {
+                        milliseconds /= 10;
+                    }
+                    builder.append(milliseconds);
+                }
+
+                if (seconds > 0 || milliseconds > 0) {
+                    builder.append('S');
+                }
+
+                result = builder.toString();
+            }
+        }
+        return result;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/FlatteningDeserializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/FlatteningDeserializer.java
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.azure.android.core.annotation.JsonFlatten;
+import com.azure.android.core.implementation.TypeUtil;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+/**
+ * Custom serializer for deserializing complex types with wrapped properties.
+ * For example, a property with annotation @JsonProperty(value = "properties.name")
+ * will be mapped to a top level "name" property in the POJO model.
+ */
+final class FlatteningDeserializer extends StdDeserializer<Object> implements ResolvableDeserializer {
+    private static final long serialVersionUID = -2133095337545715498L;
+
+    /**
+     * The default mapperAdapter for the current type.
+     */
+    private final JsonDeserializer<?> defaultDeserializer;
+
+    /**
+     * The object mapper for default deserializations.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * Creates an instance of FlatteningDeserializer.
+     * @param vc handled type
+     * @param defaultDeserializer the default JSON mapperAdapter
+     * @param mapper the object mapper for default deserializations
+     */
+    protected FlatteningDeserializer(Class<?> vc, JsonDeserializer<?> defaultDeserializer, ObjectMapper mapper) {
+        super(vc);
+        this.defaultDeserializer = defaultDeserializer;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @param mapper the object mapper for default deserializations
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule(final ObjectMapper mapper) {
+        SimpleModule module = new SimpleModule();
+        module.setDeserializerModifier(new BeanDeserializerModifier() {
+            @Override
+            public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc,
+                                                          JsonDeserializer<?> deserializer) {
+                if (beanDesc.getBeanClass().getAnnotation(JsonFlatten.class) != null) {
+                    return new FlatteningDeserializer(beanDesc.getBeanClass(), deserializer, mapper);
+                }
+                return deserializer;
+            }
+        });
+        return module;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonNode root = mapper.readTree(jp);
+        final Class<?> tClass = this.defaultDeserializer.handledType();
+        for (Class<?> c : TypeUtil.getAllClasses(tClass)) {
+            // Ignore checks for Object type.
+            if (c.isAssignableFrom(Object.class)) {
+                continue;
+            }
+            for (Field field : c.getDeclaredFields()) {
+                JsonNode node = root;
+                JsonProperty property = field.getAnnotation(JsonProperty.class);
+                if (property != null) {
+                    String value = property.value();
+                    if (value.matches(".+[^\\\\]\\..+")) {
+                        String[] values = value.split("((?<!\\\\))\\.");
+                        for (String val : values) {
+                            val = val.replace("\\.", ".");
+                            node = node.get(val);
+                            if (node == null) {
+                                break;
+                            }
+                        }
+                        ((ObjectNode) root).put(value, node);
+                    }
+                }
+            }
+        }
+        JsonParser parser = new JsonFactory().createParser(root.toString());
+        parser.nextToken();
+        return defaultDeserializer.deserialize(parser, ctxt);
+    }
+
+    @Override
+    public void resolve(DeserializationContext ctxt) throws JsonMappingException {
+        ((ResolvableDeserializer) defaultDeserializer).resolve(ctxt);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/FlatteningSerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/FlatteningSerializer.java
@@ -1,0 +1,236 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.azure.android.core.annotation.JsonFlatten;
+import com.azure.android.core.util.logging.ClientLogger;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.databind.ser.ResolvableSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.threeten.bp.Duration;
+import org.threeten.bp.OffsetDateTime;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Custom serializer for serializing types with wrapped properties.
+ * For example, a property with annotation @JsonProperty(value = "properties.name")
+ * will be mapped from a top level "name" property in the POJO model to
+ * {'properties' : { 'name' : 'my_name' }} in the serialized payload.
+ */
+class FlatteningSerializer extends StdSerializer<Object> implements ResolvableSerializer {
+    private static final long serialVersionUID = -6130180289951110573L;
+    private final ClientLogger logger = new ClientLogger(FlatteningSerializer.class);
+
+    /**
+     * The default mapperAdapter for the current type.
+     */
+    private final JsonSerializer<?> defaultSerializer;
+
+    /**
+     * The object mapper for default serializations.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * Creates an instance of FlatteningSerializer.
+     * @param vc handled type
+     * @param defaultSerializer the default JSON serializer
+     * @param mapper the object mapper for default serializations
+     */
+    protected FlatteningSerializer(Class<?> vc, JsonSerializer<?> defaultSerializer, ObjectMapper mapper) {
+        super(vc, false);
+        this.defaultSerializer = defaultSerializer;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @param mapper the object mapper for default serializations
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule(final ObjectMapper mapper) {
+        SimpleModule module = new SimpleModule();
+        module.setSerializerModifier(new BeanSerializerModifier() {
+            @Override
+            public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc,
+                                                      JsonSerializer<?> serializer) {
+                if (beanDesc.getBeanClass().getAnnotation(JsonFlatten.class) != null) {
+                    return new FlatteningSerializer(beanDesc.getBeanClass(), serializer, mapper);
+                }
+                return serializer;
+            }
+        });
+        return module;
+    }
+
+    private List<Field> getAllDeclaredFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<Field>();
+        while (clazz != null && !clazz.equals(Object.class)) {
+            for (Field f : clazz.getDeclaredFields()) {
+                int mod = f.getModifiers();
+                if (!Modifier.isFinal(mod) && !Modifier.isStatic(mod)) {
+                    fields.add(f);
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+        return fields;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void escapeMapKeys(Object value) {
+        if (value == null) {
+            return;
+        }
+
+        if (value.getClass().isPrimitive()
+            || value.getClass().isEnum()
+            || value instanceof OffsetDateTime
+            || value instanceof Duration
+            || value instanceof String) {
+            return;
+        }
+
+        int mod = value.getClass().getModifiers();
+        if (Modifier.isFinal(mod) || Modifier.isStatic(mod)) {
+            return;
+        }
+
+        if (value instanceof List<?>) {
+            for (Object val : ((List<?>) value)) {
+                escapeMapKeys(val);
+            }
+            return;
+        }
+
+        if (value instanceof Map<?, ?>) {
+            for (String key : new HashSet<>(((Map<String, Object>) value).keySet())) {
+                if (key.contains(".")) {
+                    String newKey = key.replaceAll("((?<!\\\\))\\.", "\\\\.");
+                    Object val = ((Map<String, Object>) value).remove(key);
+                    ((Map<String, Object>) value).put(newKey, val);
+                }
+            }
+            for (Object val : ((Map<?, ?>) value).values()) {
+                escapeMapKeys(val);
+            }
+            return;
+        }
+
+        for (Field f : getAllDeclaredFields(value.getClass())) {
+            f.setAccessible(true);
+            try {
+                escapeMapKeys(f.get(value));
+            } catch (IllegalAccessException e) {
+                throw logger.logExceptionAsError(new RuntimeException(e));
+            }
+        }
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if (value == null) {
+            jgen.writeNull();
+            return;
+        }
+        escapeMapKeys(value);
+        // BFS for all collapsed properties
+        ObjectNode root = mapper.valueToTree(value);
+        ObjectNode res = root.deepCopy();
+        Queue<ObjectNode> source = new LinkedBlockingQueue<ObjectNode>();
+        Queue<ObjectNode> target = new LinkedBlockingQueue<ObjectNode>();
+        source.add(root);
+        target.add(res);
+        while (!source.isEmpty()) {
+            ObjectNode current = source.poll();
+            ObjectNode resCurrent = target.poll();
+            Iterator<Map.Entry<String, JsonNode>> fields = current.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                ObjectNode node = resCurrent;
+                String key = field.getKey();
+                JsonNode outNode = resCurrent.get(key);
+                if (key.matches(".+[^\\\\]\\..+")) {
+                    // Handle flattening properties
+                    //
+                    String[] values = key.split("((?<!\\\\))\\.");
+                    for (int i = 0; i < values.length; ++i) {
+                        values[i] = values[i].replace("\\.", ".");
+                        if (i == values.length - 1) {
+                            break;
+                        }
+                        String val = values[i];
+                        if (node.has(val)) {
+                            node = (ObjectNode) node.get(val);
+                        } else {
+                            ObjectNode child = new ObjectNode(JsonNodeFactory.instance);
+                            node.put(val, child);
+                            node = child;
+                        }
+                    }
+                    node.set(values[values.length - 1], resCurrent.get(key));
+                    resCurrent.remove(key);
+                    outNode = node.get(values[values.length - 1]);
+                } else if (key.matches(".*[^\\\\]\\\\..+")) {
+                    // Handle escaped map key
+                    //
+                    String originalKey = key.replaceAll("\\\\.", ".");
+                    resCurrent.remove(key);
+                    resCurrent.put(originalKey, outNode);
+                }
+                if (field.getValue() instanceof ObjectNode) {
+                    source.add((ObjectNode) field.getValue());
+                    target.add((ObjectNode) outNode);
+                } else if (field.getValue() instanceof ArrayNode
+                    && (field.getValue()).size() > 0
+                    && (field.getValue()).get(0) instanceof ObjectNode) {
+                    Iterator<JsonNode> sourceIt = field.getValue().elements();
+                    Iterator<JsonNode> targetIt = outNode.elements();
+                    while (sourceIt.hasNext()) {
+                        source.add((ObjectNode) sourceIt.next());
+                        target.add((ObjectNode) targetIt.next());
+                    }
+                }
+            }
+        }
+        jgen.writeTree(res);
+    }
+
+    @Override
+    public void resolve(SerializerProvider provider) throws JsonMappingException {
+        ((ResolvableSerializer) defaultSerializer).resolve(provider);
+    }
+
+    @Override
+    public void serializeWithType(Object value, JsonGenerator gen, SerializerProvider provider,
+                                  TypeSerializer typeSerializer) throws IOException {
+        serialize(value, gen, provider);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/HttpHeadersSerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/HttpHeadersSerializer.java
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import okhttp3.Headers;
+
+/**
+ * Custom serializer for serializing {@code HttpHeaders} objects into Base64 strings.
+ */
+final class HttpHeadersSerializer extends JsonSerializer<Headers> {
+    /**
+     * Gets a module wrapping this serializer as an adapter for the Jackson
+     * ObjectMapper.
+     *
+     * @return a simple module to be plugged onto Jackson ObjectMapper.
+     */
+    public static SimpleModule getModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(Headers.class, new HttpHeadersSerializer());
+        return module;
+    }
+
+    @Override
+    public void serialize(Headers value, JsonGenerator jgen,
+                          SerializerProvider provider) throws IOException {
+        final Map<String, String> result = new HashMap<>();
+        for (String headerName : value.names()) {
+            result.put(headerName, value.get(headerName));
+        }
+        jgen.writeObject(result);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/JacksonAdapter.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/JacksonAdapter.java
@@ -1,0 +1,285 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import android.text.TextUtils;
+
+import com.azure.android.core.annotation.HeaderCollection;
+import com.azure.android.core.implementation.TypeUtil;
+import com.azure.android.core.util.logging.ClientLogger;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import okhttp3.Headers;
+
+/**
+ * Implementation of {@link SerializerAdapter} for Jackson.
+ */
+public class JacksonAdapter implements SerializerAdapter {
+    private final ClientLogger logger = new ClientLogger(JacksonAdapter.class);
+
+    /**
+     * An instance of {@link ObjectMapper} to serialize/deserialize objects.
+     */
+    private final ObjectMapper mapper;
+
+    /**
+     * An instance of {@link ObjectMapper} that does not do flattening.
+     */
+    private final ObjectMapper simpleMapper;
+
+    private final XmlMapper xmlMapper;
+
+    private final ObjectMapper headerMapper;
+
+    private static SerializerAdapter serializerAdapter;
+
+    /*
+     * BOM header from some response bodies. To be removed in deserialization.
+     */
+    private static final String BOM = "\uFEFF";
+
+    /**
+     * Creates a new JacksonAdapter instance with default mapper settings.
+     */
+    public JacksonAdapter() {
+        simpleMapper = initializeObjectMapper(new ObjectMapper());
+        xmlMapper = initializeObjectMapper(new XmlMapper());
+        xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        xmlMapper.setDefaultUseWrapper(false);
+        ObjectMapper flatteningMapper = initializeObjectMapper(new ObjectMapper())
+                .registerModule(FlatteningSerializer.getModule(simpleMapper()))
+                .registerModule(FlatteningDeserializer.getModule(simpleMapper()));
+        mapper = initializeObjectMapper(new ObjectMapper())
+                // Order matters: must register in reverse order of hierarchy
+                .registerModule(AdditionalPropertiesSerializer.getModule(flatteningMapper))
+                .registerModule(AdditionalPropertiesDeserializer.getModule(flatteningMapper))
+                .registerModule(FlatteningSerializer.getModule(simpleMapper()))
+                .registerModule(FlatteningDeserializer.getModule(simpleMapper()));
+        headerMapper = simpleMapper
+                .copy()
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+    }
+
+    /**
+     * Gets a static instance of {@link ObjectMapper} that doesn't handle flattening.
+     *
+     * @return an instance of {@link ObjectMapper}.
+     */
+    protected ObjectMapper simpleMapper() {
+        return simpleMapper;
+    }
+
+    /**
+     * maintain singleton instance of the default serializer adapter.
+     *
+     * @return the default serializer
+     */
+    public static synchronized SerializerAdapter createDefaultSerializerAdapter() {
+        if (serializerAdapter == null) {
+            serializerAdapter = new JacksonAdapter();
+        }
+        return serializerAdapter;
+    }
+
+    /**
+     * @return the original serializer type
+     */
+    public ObjectMapper serializer() {
+        return mapper;
+    }
+
+    @Override
+    public String serialize(Object object, SerializerEncoding encoding) throws IOException {
+        if (object == null) {
+            return null;
+        }
+        StringWriter writer = new StringWriter();
+        if (encoding == SerializerEncoding.XML) {
+            xmlMapper.writeValue(writer, object);
+        } else {
+            serializer().writeValue(writer, object);
+        }
+
+        return writer.toString();
+    }
+
+    @Override
+    public String serializeRaw(Object object) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            return serialize(object, SerializerEncoding.JSON).replaceAll("^\"*", "").replaceAll("\"*$", "");
+        } catch (IOException ex) {
+            logger.warning("Failed to serialize {} to JSON.", object.getClass(), ex);
+            return null;
+        }
+    }
+
+    @Override
+    public String serializeList(List<?> list, CollectionFormat format) {
+        if (list == null) {
+            return null;
+        }
+        List<String> serialized = new ArrayList<>();
+        for (Object element : list) {
+            String raw = serializeRaw(element);
+            serialized.add(raw != null ? raw : "");
+        }
+        return TextUtils.join(format.getDelimiter(), serialized);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T deserialize(String value, final Type type, SerializerEncoding encoding) throws IOException {
+        if (value == null || value.isEmpty() || value.equals(BOM)) {
+            return null;
+        }
+        // Remove BOM
+        if (value.startsWith(BOM)) {
+            value = value.replaceFirst(BOM, "");
+        }
+
+        final JavaType javaType = createJavaType(type);
+        try {
+            if (encoding == SerializerEncoding.XML) {
+                return (T) xmlMapper.readValue(value, javaType);
+            } else {
+                return (T) serializer().readValue(value, javaType);
+            }
+        } catch (JsonParseException jpe) {
+            throw logger.logExceptionAsError(new MalformedValueException(jpe.getMessage(), jpe));
+        }
+    }
+
+    @Override
+    public <T> T deserialize(Headers headers, Type deserializedHeadersType) throws IOException {
+        if (deserializedHeadersType == null) {
+            return null;
+        }
+
+        final String headersJsonString = headerMapper.writeValueAsString(headers);
+        T deserializedHeaders =
+                headerMapper.readValue(headersJsonString, createJavaType(deserializedHeadersType));
+
+        final Class<?> deserializedHeadersClass = TypeUtil.getRawClass(deserializedHeadersType);
+        final Field[] declaredFields = deserializedHeadersClass.getDeclaredFields();
+        for (final Field declaredField : declaredFields) {
+            if (declaredField.isAnnotationPresent(HeaderCollection.class)) {
+                final Type declaredFieldType = declaredField.getGenericType();
+                if (TypeUtil.isTypeOrSubTypeOf(declaredField.getType(), Map.class)) {
+                    final Type[] mapTypeArguments = TypeUtil.getTypeArguments(declaredFieldType);
+                    if (mapTypeArguments.length == 2
+                            && mapTypeArguments[0] == String.class
+                            && mapTypeArguments[1] == String.class) {
+                        final HeaderCollection headerCollectionAnnotation =
+                                declaredField.getAnnotation(HeaderCollection.class);
+                        final String headerCollectionPrefix =
+                                headerCollectionAnnotation.value().toLowerCase(Locale.ROOT);
+                        final int headerCollectionPrefixLength = headerCollectionPrefix.length();
+                        if (headerCollectionPrefixLength > 0) {
+                            final Map<String, String> headerCollection = new HashMap<>();
+                            for (String headerName : headers.names()) {
+                                if (headerName.toLowerCase(Locale.ROOT).startsWith(headerCollectionPrefix)) {
+                                    headerCollection.put(headerName.substring(headerCollectionPrefixLength),
+                                            headers.get(headerName));
+                                }
+                            }
+
+                            final boolean declaredFieldAccessibleBackup = declaredField.isAccessible();
+                            try {
+                                if (!declaredFieldAccessibleBackup) {
+                                    // TODO: anuchan: double check Android SecurityManger does not get into way when changing field visibility.
+                                    declaredField.setAccessible(true);
+                                }
+                                declaredField.set(deserializedHeaders, headerCollection);
+                            } catch (IllegalAccessException ignored) {
+                            } finally {
+                                if (!declaredFieldAccessibleBackup) {
+                                    declaredField.setAccessible(declaredFieldAccessibleBackup);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return deserializedHeaders;
+    }
+
+    /**
+     * Initializes an instance of JacksonMapperAdapter with default configurations
+     * applied to the object mapper.
+     *
+     * @param mapper the object mapper to use.
+     */
+    private static <T extends ObjectMapper> T initializeObjectMapper(T mapper) {
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, true)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                // TODO: anuchan: there is no official jackson converter for three-ten time-lib
+                // add module for three-ten with serializer and deserializer
+                // for OffsetDateTime and Duration which we support in generated code level.
+                // .registerModule(new JavaTimeModule())
+                .registerModule(ByteArraySerializer.getModule())
+                .registerModule(Base64UrlSerializer.getModule())
+                .registerModule(DateTimeSerializer.getModule())
+                .registerModule(DateTimeRfc1123Serializer.getModule())
+                .registerModule(DurationSerializer.getModule())
+                .registerModule(HttpHeadersSerializer.getModule());
+        mapper.setVisibility(mapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE));
+        return mapper;
+    }
+
+    private JavaType createJavaType(Type type) {
+        JavaType result;
+        if (type == null) {
+            result = null;
+        } else if (type instanceof JavaType) {
+            result = (JavaType) type;
+        } else if (type instanceof ParameterizedType) {
+            final ParameterizedType parameterizedType = (ParameterizedType) type;
+            final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+            JavaType[] javaTypeArguments = new JavaType[actualTypeArguments.length];
+            for (int i = 0; i != actualTypeArguments.length; i++) {
+                javaTypeArguments[i] = createJavaType(actualTypeArguments[i]);
+            }
+            result = mapper
+                    .getTypeFactory().constructParametricType((Class<?>) parameterizedType.getRawType(), javaTypeArguments);
+        } else {
+            result = mapper
+                    .getTypeFactory().constructType(type);
+        }
+        return result;
+    }
+
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/MalformedValueException.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/MalformedValueException.java
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+/**
+ * An exception thrown while parsing an invalid input during serialization or deserialization.
+ */
+public class MalformedValueException extends RuntimeException {
+    /**
+     * Create a MalformedValueException instance.
+     *
+     * @param message the exception message
+     */
+    public MalformedValueException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create a MalformedValueException instance.
+     *
+     * @param message the exception message
+     * @param cause the actual cause
+     */
+    public MalformedValueException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/SerializerAdapter.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/SerializerAdapter.java
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import okhttp3.Headers;
+
+/**
+ * An interface defining the behaviors of a serializer.
+ */
+public interface SerializerAdapter {
+    /**
+     * Serializes an object into a string.
+     *
+     * @param object the object to serialize
+     * @param encoding the encoding to use for serialization
+     * @return the serialized string. Null if the object to serialize is null
+     * @throws IOException exception from serialization
+     */
+    String serialize(Object object, SerializerEncoding encoding) throws IOException;
+
+    /**
+     * Serializes an object into a raw string. The leading and trailing quotes will be trimmed.
+     *
+     * @param object the object to serialize
+     * @return the serialized string. Null if the object to serialize is null
+     */
+    String serializeRaw(Object object);
+
+    /**
+     * Serializes a list into a string with the delimiter specified with the
+     * Swagger collection format joining each individual serialized items in
+     * the list.
+     *
+     * @param list the list to serialize
+     * @param format the Swagger collection format
+     * @return the serialized string
+     */
+    String serializeList(List<?> list, CollectionFormat format);
+
+    /**
+     * Deserializes a string into a {@code U} object.
+     *
+     * @param value the string value to deserialize
+     * @param <U> the type of the deserialized object
+     * @param type the type to deserialize
+     * @param encoding the encoding used in the serialized value
+     * @return the deserialized object
+     * @throws IOException exception from deserialization
+     */
+    <U> U deserialize(String value, Type type, SerializerEncoding encoding) throws IOException;
+
+    /**
+     * Deserialize the provided headers returned from a REST API to an entity instance declared as
+     * the model to hold 'Matching' headers.
+     *
+     * @param headers the REST API returned headers
+     * @param <U> the type of the deserialized object
+     * @param type the type to deserialize
+     * @return instance of header entity type created based on provided {@code headers}, if header entity model does
+     *     not exists then return null
+     * @throws IOException If an I/O error occurs
+     */
+    <U> U deserialize(Headers headers, Type type) throws IOException;
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/SerializerEncoding.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/serializer/SerializerEncoding.java
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.util.serializer;
+
+import okhttp3.Headers;
+
+/**
+ * Supported serialization encoding formats.
+ */
+public enum SerializerEncoding {
+    /**
+     * JavaScript Object Notation.
+     */
+    JSON,
+
+    /**
+     * Extensible Markup Language.
+     */
+    XML;
+
+    /**
+     * Determines the serializer encoding to use based on the Content-Type header.
+     *
+     * @param headers the headers to check the encoding for
+     * @return the serializer encoding to use for the body
+     */
+    public static SerializerEncoding fromHeaders(Headers headers) {
+        String mimeContentType = headers.get("Content-Type");
+        if (mimeContentType != null) {
+            String[] parts = mimeContentType.split(";");
+            if (parts[0].equalsIgnoreCase("application/xml")
+                    || parts[0].equalsIgnoreCase("text/xml")) {
+                return XML;
+            }
+        }
+        return JSON;
+    }
+}


### PR DESCRIPTION

Changes Proposed in this pull request:

- Adding Serializer abstraction and Jackson based implementation. Partially fixes https://github.com/Azure/azure-sdk-for-android/issues/125, pending work is mapper for threeten time types.
- Adding slf4j android based logging abstraction. Fixes https://github.com/Azure/azure-sdk-for-android/issues/127
- Adding type to initialize Retrofit and  create service client based on it. Kickoff "Implement basic HTTP Pipeline with OkHttp + Retrofit" work item in https://github.com/Azure/azure-sdk-for-android/issues/119
