### PR TITLE
Remove Kotlin dependency 

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -27,7 +27,7 @@ allprojects {
         annotationsVersion = "1.1.0"
         jacksonDatabindVersion = "2.9.9"
         jacksonDataFormatXmlVersion = "2.9.9"
-        okHttpVersion = "4.2.2"
+        okHttpVersion = "3.13.1"
         retrofitVersion = "2.6.2"
         slf4jAndroidVersion = "1.7.29"
         staxApiVersion = "1.0-2"

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/CurlLoggingInterceptor.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/CurlLoggingInterceptor.java
@@ -6,14 +6,12 @@ package com.azure.android.core.http.interceptor;
 import com.azure.android.core.util.CoreUtils;
 import com.azure.android.core.util.logging.ClientLogger;
 
-import org.jetbrains.annotations.NotNull;
-
+import androidx.annotation.NonNull;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import kotlin.Pair;
 import okhttp3.Headers;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
@@ -38,9 +36,9 @@ public class CurlLoggingInterceptor implements Interceptor {
         compressed = false;
     }
 
-    @NotNull
+    @NonNull
     @Override
-    public Response intercept(@NotNull Chain chain) throws IOException {
+    public Response intercept(@NonNull Chain chain) throws IOException {
         Request request = chain.request();
         Headers headers = request.headers();
 
@@ -76,10 +74,10 @@ public class CurlLoggingInterceptor implements Interceptor {
      * @param curlCommand StringBuilder that is generating the cURL command.
      */
     private void addHeadersToCurlCommand(Headers headers, StringBuilder curlCommand) {
-        for (Pair<? extends String, ? extends String> header : headers) {
-            String headerName = header.getFirst();
-            String headerValue = header.getSecond();
-
+        int size = headers.size();
+        for (int i = 0; i < size; i++) {
+            String headerName = headers.name(i);
+            String headerValue = headers.value(i);
             if (headerValue.startsWith("\"") || headerValue.endsWith("\"")) {
                 headerValue = "\\\"" + headerValue.replaceAll("\"", "") + "\\\"";
             }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/LoggingInterceptor.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/LoggingInterceptor.java
@@ -14,7 +14,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import kotlin.Pair;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
@@ -172,14 +171,13 @@ public final class LoggingInterceptor implements Interceptor {
      * @param headers HTTP headers on the request or response.
      */
     private void logHeaders(Headers headers) {
-        for (Pair<? extends String, ? extends String> header : headers) {
-            String headerName = header.getFirst();
-            String headerValue = header.getSecond();
-
+        int size = headers.size();
+        for (int i = 0; i < size; i++) {
+            String headerName = headers.name(i);
+            String headerValue = headers.value(i);
             if (!allowedHeaderNames.contains(headerName.toLowerCase(Locale.ROOT))) {
                 headerValue = LogUtils.REDACTED_PLACEHOLDER;
             }
-
             logger.verbose(headerName + ": " + headerValue);
         }
     }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/http/rest/RetrofitAPIClient.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/http/rest/RetrofitAPIClient.java
@@ -98,10 +98,9 @@ public class RetrofitAPIClient {
                                                                   Annotation[] parameterAnnotations,
                                                                   Annotation[] methodAnnotations,
                                                                   Retrofit retrofit) {
-                return value -> RequestBody.create(serializer.serialize(value, encoding),
-                        encoding == SerializerEncoding.XML
-                                ? XML_MEDIA_TYPE
-                                : JSON_MEDIA_TYPE);
+                return value -> RequestBody.create(encoding == SerializerEncoding.XML
+                        ? XML_MEDIA_TYPE
+                        : JSON_MEDIA_TYPE, serializer.serialize(value, encoding));
             }
 
             @Override

--- a/sdk/storage/azure-storage-common/src/main/java/com/azure/android/storage/common/interceptor/ResponseHeadersValidationInterceptor.java
+++ b/sdk/storage/azure-storage-common/src/main/java/com/azure/android/storage/common/interceptor/ResponseHeadersValidationInterceptor.java
@@ -1,9 +1,9 @@
 package com.azure.android.storage.common.interceptor;
 
+import androidx.annotation.NonNull;
+
 import com.azure.android.core.util.logging.ClientLogger;
 import com.azure.android.core.util.CoreUtils;
-
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,9 +41,9 @@ public class ResponseHeadersValidationInterceptor implements Interceptor {
         this.headerNames.addAll(headerNames);
     }
 
-    @NotNull
+    @NonNull
     @Override
-    public Response intercept(@NotNull Chain chain) throws IOException {
+    public Response intercept(@NonNull Chain chain) throws IOException {
         Request request = chain.request();
         Response response = chain.proceed(request);
 


### PR DESCRIPTION
OkHttp v4.x brings Kotlin dependency, this PR changes the OkHttp version to v3.13.1 and removes Kotlin types usages in the code.

The  v3.13.1 is the one I used to build and test storage sample application. I see people hitting issues with minor version upgrades,  we will update to latest 3.x version once we test with it. v3.14.4 is the latest 3.x as of today.

