### PR TITLE
serialization updates and expandable-enum

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/BiFunction.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/BiFunction.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package com.azure.android.core.implementation.util.serializer;
 
 /**

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/ByteArraySerializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/ByteArraySerializer.java
@@ -1,8 +1,7 @@
-package com.azure.android.core.implementation.util.serializer;
-
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+package com.azure.android.core.implementation.util.serializer;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/DateTimeRfc1123Serializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/DateTimeRfc1123Serializer.java
@@ -6,7 +6,6 @@ package com.azure.android.core.implementation.util.serializer;
 import com.azure.android.core.util.DateTimeRfc1123;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
@@ -31,10 +30,6 @@ final class DateTimeRfc1123Serializer extends JsonSerializer<DateTimeRfc1123> {
     @Override
     public void serialize(DateTimeRfc1123 value, JsonGenerator jgen,
                           SerializerProvider provider) throws IOException {
-        if (provider.isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)) {
-            jgen.writeNumber(value.dateTime().getTime());
-        } else {
-            jgen.writeString(value.toString()); //Use the default toString as it is RFC1123.
-        }
+        jgen.writeString(value.toString()); //Use the default toString as it is RFC1123.
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/SerializerAdapter.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/SerializerAdapter.java
@@ -5,6 +5,7 @@ package com.azure.android.core.implementation.util.serializer;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.List;
 
 import okhttp3.Headers;
 
@@ -21,6 +22,17 @@ public interface SerializerAdapter {
      * @throws IOException exception from serialization
      */
     String serialize(Object object, SerializerEncoding encoding) throws IOException;
+
+    /**
+     * Serializes a list into a string with the delimiter specified with the
+     * Swagger collection format joining each individual serialized items in
+     * the list.
+     *
+     * @param list the list to serialize
+     * @param format the Swagger collection format
+     * @return the serialized string
+     */
+    String serializeList(List<?> list, CollectionFormat format);
 
     /**
      * Deserializes a string into a {@code U} object.
@@ -52,5 +64,57 @@ public interface SerializerAdapter {
      */
     static SerializerAdapter createDefault() {
         return JacksonAdapter.createDefaultSerializerAdapter();
+    }
+
+    enum CollectionFormat {
+        /**
+         * Comma separated values.
+         * E.g. foo,bar
+         */
+        CSV(","),
+        /**
+         * Space separated values.
+         * E.g. foo bar
+         */
+        SSV(" "),
+        /**
+         * Tab separated values.
+         * E.g. foo\tbar
+         */
+        TSV("\t"),
+        /**
+         * Pipe(|) separated values.
+         * E.g. foo|bar
+         */
+        PIPES("|"),
+        /**
+         * Corresponds to multiple parameter instances instead of multiple values
+         * for a single instance.
+         * E.g. foo=bar&amp;foo=baz
+         */
+        MULTI("&");
+
+        /**
+         * The delimiter separating the values.
+         */
+        private String delimiter;
+
+        /**
+         * Creates CollectionFormat enum.
+         *
+         * @param delimiter the delimiter as a string.
+         */
+        CollectionFormat(String delimiter) {
+            this.delimiter = delimiter;
+        }
+
+        /**
+         * Gets the delimiter used to join a list of parameters.
+         *
+         * @return the delimiter of the current collection format.
+         */
+        public String getDelimiter() {
+            return delimiter;
+        }
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/DateTimeRfc1123.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/DateTimeRfc1123.java
@@ -3,52 +3,47 @@
 
 package com.azure.android.core.util;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import org.threeten.bp.OffsetDateTime;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.format.DateTimeFormatter;
+
 import java.util.Locale;
-import java.util.TimeZone;
 
 /**
- * Wrapper over java.util.Date used for specifying RFC1123 formatted time.
+ * Wrapper over java.time.OffsetDateTime used for specifying RFC1123 format during serialization and deserialization.
  */
 public final class DateTimeRfc1123 {
-
-    private static final String RFC1123_DATE_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
-
     /**
-     * The actual Date object.
+     * The pattern of the datetime used for RFC1123 datetime format.
      */
-    private final Date dateTime;
+    private static final DateTimeFormatter RFC1123_DATE_TIME_FORMATTER =
+        DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(ZoneId.of("UTC")).withLocale(Locale.US);
+    /**
+     * The actual datetime object.
+     */
+    private final OffsetDateTime dateTime;
 
     /**
      * Creates a new DateTimeRfc1123 object with the specified DateTime.
-     * @param dateTime The Date object to wrap.
+     * @param dateTime The DateTime object to wrap.
      */
-    public DateTimeRfc1123(Date dateTime) {
+    public DateTimeRfc1123(OffsetDateTime dateTime) {
         this.dateTime = dateTime;
     }
 
     /**
      * Creates a new DateTimeRfc1123 object with the specified DateTime.
-     * @param formattedString The Date string in RFC1123 format
+     * @param formattedString The datetime string in RFC1123 format
      */
     public DateTimeRfc1123(String formattedString) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(RFC1123_DATE_TIME_FORMAT, Locale.US);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-        try {
-            this.dateTime = dateFormat.parse(formattedString);
-        } catch (ParseException pe) {
-            throw new RuntimeException(pe);
-        }
+        this.dateTime = OffsetDateTime.parse(formattedString, DateTimeFormatter.RFC_1123_DATE_TIME);
     }
 
     /**
-     * Returns the underlying Date.
-     * @return The underlying Date.
+     * Returns the underlying DateTime.
+     * @return The underlying DateTime.
      */
-    public Date dateTime() {
+    public OffsetDateTime getDateTime() {
         if (this.dateTime == null) {
             return null;
         }
@@ -57,9 +52,7 @@ public final class DateTimeRfc1123 {
 
     @Override
     public String toString() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(RFC1123_DATE_TIME_FORMAT, Locale.US);
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return dateFormat.format(this.dateTime);
+        return RFC1123_DATE_TIME_FORMATTER.format(this.dateTime);
     }
 
     @Override
@@ -78,6 +71,6 @@ public final class DateTimeRfc1123 {
         }
 
         DateTimeRfc1123 rhs = (DateTimeRfc1123) obj;
-        return this.dateTime.equals(rhs.dateTime());
+        return this.dateTime.equals(rhs.getDateTime());
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/ExpandableStringEnum.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/ExpandableStringEnum.java
@@ -1,0 +1,115 @@
+package com.azure.android.core.util;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Base implementation for expandable, single string enums.
+ *
+ * @param <T> a specific expandable enum type
+ */
+public abstract class ExpandableStringEnum<T extends ExpandableStringEnum<T>> {
+    private static final ConcurrentMap<String,
+            ? extends ExpandableStringEnum<?>> VALUES_BY_NAME = new ConcurrentHashMap<>();
+
+    private String name;
+    private Class<T> clazz;
+
+    private static String uniqueKey(Class<?> clazz, String name) {
+        if (clazz != null) {
+            return (clazz.getName() + "#" + name).toLowerCase(Locale.ROOT);
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    T nameValue(String name, T value, Class<T> clazz) {
+        this.name = name;
+        this.clazz = clazz;
+        ((ConcurrentMap<String, T>) VALUES_BY_NAME).put(uniqueKey(clazz, name), value);
+        return (T) this;
+    }
+
+    /**
+     * Creates an instance of the specific expandable string enum from a String.
+     *
+     * @param name The value to create the instance from.
+     * @param clazz The class of the expandable string enum.
+     * @param <T> the class of the expandable string enum.
+     * @return The expandable string enum instance.
+     */
+    @SuppressWarnings("unchecked")
+    protected static <T extends ExpandableStringEnum<T>> T fromString(String name, Class<T> clazz) {
+        if (name == null) {
+            return null;
+        } else {
+            T value = (T) VALUES_BY_NAME.get(uniqueKey(clazz, name));
+            if (value != null) {
+                return value;
+            }
+        }
+
+        try {
+            T value = clazz.newInstance();
+            return value.nameValue(name, value, clazz);
+        } catch (InstantiationException | IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets a collection of all known values to an expandable string enum type.
+     *
+     * @param clazz the class of the expandable string enum.
+     * @param <T> the class of the expandable string enum.
+     * @return A collection of all known values for the given {@code clazz}.
+     */
+    @SuppressWarnings("unchecked")
+    protected static <T extends ExpandableStringEnum<T>> Collection<T> values(Class<T> clazz) {
+        // Make a copy of all values
+        Collection<? extends ExpandableStringEnum<?>> values = new ArrayList<>(VALUES_BY_NAME.values());
+
+        Collection<T> list = new HashSet<T>();
+        for (ExpandableStringEnum<?> value : values) {
+            if (value.getClass().isAssignableFrom(clazz)) {
+                list.add((T) value);
+            }
+        }
+
+        return list;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return this.name;
+    }
+
+    @Override
+    public int hashCode() {
+        return uniqueKey(this.clazz, this.name).hashCode();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (clazz == null || !clazz.isAssignableFrom(obj.getClass())) {
+            return false;
+        } else if (obj == this) {
+            return true;
+        } else if (this.name == null) {
+            return ((ExpandableStringEnum<T>) obj).name == null;
+        } else {
+            return this.name.equals(((ExpandableStringEnum<T>) obj).name);
+        }
+    }
+}


### PR DESCRIPTION

### Serialization updates:
1. Update Jackson adapter to register threeten adapters.
2. Adding SerializerAdapter::serializeList(List, CollectionFormat) method.
3. Updating DateTimeRfc1123 to use threeten types.
4. OkHttpHeaders are not serializable, hence convert it to a map and then serialize.

### expandable enum
1. Adding ExpandableEnum for extensible enum.