### PR TITLE
Corrected reference in JacksonAdapter for class that was renamed.

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/JacksonAdapter.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/implementation/util/serializer/JacksonAdapter.java
@@ -291,7 +291,7 @@ public class JacksonAdapter implements SerializerAdapter {
             return null;
         }
         try {
-            return serialize(object, SerializerEncoding.JSON)
+            return serialize(object, SerializerFormat.JSON)
                     .replaceAll("^\"*", "")
                     .replaceAll("\"*$", "");
         } catch (IOException ex) {


### PR DESCRIPTION
In a previous PR we renamed SerializerEncoding to SerializerFormat but missed a reference in JacksonAdapter. This PR corrects that.