### PR TITLE
Basic build via CI.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -13,8 +13,7 @@ jobs:
 
     steps:
       - script: |
-          echo Hello, world!
-        displayName: A task
+          ./gradlew sdk:${{parameters.ServiceDirectory}}:build
 
   - job: 'Analyze'
 

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -20,8 +20,7 @@ trigger:
       - release/*
   paths:
     include:
-      - sdk/core/
-      - eng/
+      - sdk/storage/
 
 pr:
   branches:
@@ -32,14 +31,13 @@ pr:
       - release/*
   paths:
     include:
-      - sdk/core/
-      - eng/
+      - sdk/storage/
       
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
     parameters:
-      ServiceDirectory: core
+      ServiceDirectory: storage
       Artifacts:
-        - name: azure-core
-          safeName: azurecore
+        - name: azure-storage-blob
+          safeName: azurestorageblob
           stagingProfileId: 88192f04117501


### PR DESCRIPTION
This PR builds out the basic build steps for the gradle build. Our build process is designed to build the set of files in the ```sdk/[service]``` directory (we'll have a pipeline for each one like we do for the Java pipelines). The thing that we need to figure out is binary vs. source composition (although we probably want to get further along before we start trying to figure that out.