### PR TITLE
Generate -sources.jar, -javadoc.jar, *.jar and *.pom files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ configure([
         }
 
         lintOptions {
-            lintConfig file("$rootDir/sdk/lint.xml")
+            lintConfig file("$rootDir/eng/lint.xml")
         }
 
         buildTypes {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,23 @@ buildscript {
     }
 }
 
+configure([
+    project("sdk:core:azure-core"),
+    project("sdk:storage:azure-storage-blob")]) {
+
+    apply plugin: "com.android.library"
+    apply plugin: "maven"
+
+    task sourcesJar(type: Jar) { -> project
+        from android.sourceSets.main.java.srcDirs
+        classifier = "sources"
+    }
+
+    artifacts {
+        archives sourcesJar
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -71,23 +71,34 @@ configure([
         classifier = "sources"
     }
 
-    // task javadoc(type: Javadoc) {
-    //     source = android.sourceSets.main.java.srcDirs
-    //     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    // }
+    task javadoc(type: Javadoc) {
+        failOnError false
+        source = android.sourceSets.main.java.srcDirs
+        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    }
 
-    // task javadocJar(type: Jar, dependsOn: javadoc) {
-    //     classifier = 'javadoc'
-    //     from javadoc.destinationDir
-    // }
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
 
     project.afterEvaluate {
+        javadoc.classpath += files(android.libraryVariants.collect { variant ->
+            variant.javaCompile.classpath.files
+        })
+
         publishing { -> project
             publications {
                 maven(MavenPublication) { -> project
                     artifact bundleReleaseAar
                     artifact sourcesJar
-//                    artifact javadocJar
+                    artifact javadocJar
+                }
+            }
+
+            repositories {
+                maven {
+                    url = "$buildDir/repo/"
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -23,15 +23,76 @@ configure([
 
     apply plugin: "com.android.library"
     apply plugin: "maven"
+    apply plugin: "maven-publish"
 
-    task sourcesJar(type: Jar) { -> project
+
+    android { -> project
+        compileSdkVersion 29
+        buildToolsVersion "29.0.2"
+
+        defaultConfig {
+            minSdkVersion 21
+            targetSdkVersion 29
+            versionCode 1
+            versionName "1.0.0-beta.1"
+            testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        }
+
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+
+        lintOptions {
+            lintConfig file("$rootDir/sdk/lint.xml")
+        }
+
+        buildTypes {
+            release {
+                minifyEnabled false
+                proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
+            }
+
+            debug {
+                debuggable true
+            }
+        }
+
+        testOptions {
+            unitTests {
+                includeAndroidResources = true
+            }
+        }
+
+    }
+
+    task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs
         classifier = "sources"
     }
 
-    artifacts {
-        archives sourcesJar
+    // task javadoc(type: Javadoc) {
+    //     source = android.sourceSets.main.java.srcDirs
+    //     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    // }
+
+    // task javadocJar(type: Jar, dependsOn: javadoc) {
+    //     classifier = 'javadoc'
+    //     from javadoc.destinationDir
+    // }
+
+    project.afterEvaluate {
+        publishing { -> project
+            publications {
+                maven(MavenPublication) { -> project
+                    artifact bundleReleaseAar
+                    artifact sourcesJar
+//                    artifact javadocJar
+                }
+            }
+        }
     }
+
 }
 
 allprojects {
@@ -53,12 +114,11 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
+// Why do we need this?
+// task clean(type: Delete) {
+//     delete rootProject.buildDir
+// }
 
-// Synthesize dependencies for service-level projects so that running a task on a service-level project automatically
-// runs it on all subprojects of that project
 configure(subprojects.findAll { it.path.count(':') == 2 }) {
     project.gradle.startParameter.taskNames.each { task ->
         task = task.split(':').last()

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -13,7 +13,17 @@ jobs:
 
     steps:
       - script: |
-          ./gradlew sdk:${{parameters.ServiceDirectory}}:build sdk:${{parameters.ServiceDirectory}}:publishToMavenLocal
+          ./gradlew sdk:${{parameters.ServiceDirectory}}:build sdk:${{parameters.ServiceDirectory}}:publish
+        displayName: Build packages
+      - ${{ each artifact in parameters.Artifacts }}:
+        - pwsh: |
+            $artifactsToStage = Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}} | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar)$" }
+            $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
+            $artifactsToStage | Copy-Item -Destination $stagingLocation
+          displayName: Stage ${{artifact.name}} for upload
+      - publish: $(Build.ArtifactStagingDirectory)
+        artifact: packages
+        displayName: Upload artifacts
 
   - job: 'Analyze'
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -18,6 +18,7 @@ jobs:
       - ${{ each artifact in parameters.Artifacts }}:
         - pwsh: |
             $artifactsToStage = Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}} | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar)$" }
+            Write-Host $artifactsToStage
             $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
             $artifactsToStage | Copy-Item -Destination $stagingLocation
           displayName: Stage ${{artifact.name}} for upload

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -17,7 +17,7 @@ jobs:
         displayName: Build packages
       - ${{ each artifact in parameters.Artifacts }}:
         - pwsh: |
-            Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}}
+            Get-ChildItem sdk/${{parameters.ServiceDirectory}}/**/*.jar
             # $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
             # $artifactsToStage | Copy-Item -Destination $stagingLocation
           displayName: Stage ${{artifact.name}} for upload

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -17,14 +17,13 @@ jobs:
         displayName: Build packages
       - ${{ each artifact in parameters.Artifacts }}:
         - pwsh: |
-            $artifactsToStage = Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}} | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar)$" }
-            Write-Host $artifactsToStage
-            $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
-            $artifactsToStage | Copy-Item -Destination $stagingLocation
+            Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}}
+            # $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
+            # $artifactsToStage | Copy-Item -Destination $stagingLocation
           displayName: Stage ${{artifact.name}} for upload
-      - publish: $(Build.ArtifactStagingDirectory)
-        artifact: packages
-        displayName: Upload artifacts
+      # - publish: $(Build.ArtifactStagingDirectory)
+      #   artifact: packages
+      #   displayName: Upload artifacts
 
   - job: 'Analyze'
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -17,13 +17,13 @@ jobs:
         displayName: Build packages
       - ${{ each artifact in parameters.Artifacts }}:
         - pwsh: |
-            Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}} -Recurse | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar)$" }
-            #$stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
-            #$artifactsToStage | Copy-Item -Destination $stagingLocation
+            $artifactsToStage = Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}}* -Recurse | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar)$" }
+            $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
+            $artifactsToStage | Copy-Item -Destination $stagingLocation
           displayName: Stage ${{artifact.name}} for upload
-      # - publish: $(Build.ArtifactStagingDirectory)
-      #   artifact: packages
-      #   displayName: Upload artifacts
+      - publish: $(Build.ArtifactStagingDirectory)
+        artifact: packages
+        displayName: Upload artifacts
 
   - job: 'Analyze'
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - script: |
-          ./gradlew sdk:${{parameters.ServiceDirectory}}:build
+          ./gradlew sdk:${{parameters.ServiceDirectory}}:build sdk:${{parameters.ServiceDirectory}}:publishToMavenLocal
 
   - job: 'Analyze'
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -17,9 +17,9 @@ jobs:
         displayName: Build packages
       - ${{ each artifact in parameters.Artifacts }}:
         - pwsh: |
-            Get-ChildItem sdk/${{parameters.ServiceDirectory}}/**/*.jar
-            # $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
-            # $artifactsToStage | Copy-Item -Destination $stagingLocation
+            Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}} -Recurse | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar)$" }
+            #$stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
+            #$artifactsToStage | Copy-Item -Destination $stagingLocation
           displayName: Stage ${{artifact.name}} for upload
       # - publish: $(Build.ArtifactStagingDirectory)
       #   artifact: packages

--- a/sdk/core/azure-core/build.gradle
+++ b/sdk/core/azure-core/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "com.android.library"
 
+version = "1.0.0-beta.1"
+
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
@@ -8,7 +10,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0-beta.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -51,4 +53,24 @@ dependencies {
     implementation "javax.xml.stream:stax-api:$staxApiVersion" // https://stackoverflow.com/a/47371517/1473510
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
     testImplementation "junit:junit:$jUnitVersion"
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = "sources"
+}
+
+// task javadoc(type: Javadoc) {
+//     source = android.sourceSets.main.java.srcDirs
+//     classpath += project.files(android.getBootClasspath().join(File.pathSeprator))
+// }
+
+// task javadocJar(type: Jar, dependsOn: javadoc) {
+//     classifier = 'javadoc'
+//     from javadoc.destinationDir
+// }
+
+artifacts {
+    archives sourcesJar
+//    archives javadocJar
 }

--- a/sdk/core/azure-core/build.gradle
+++ b/sdk/core/azure-core/build.gradle
@@ -1,44 +1,5 @@
 version = "1.0.0-beta.1"
-
-android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
-
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0.0-beta.1"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    lintOptions {
-        lintConfig file("$rootDir/eng/lint.xml")
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
-        }
-
-        debug {
-            debuggable true
-        }
-    }
-
-    testOptions {
-        unitTests {
-            includeAndroidResources = true
-        }
-    }
-
-}
+group = "com.azure.android"
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/sdk/core/azure-core/build.gradle
+++ b/sdk/core/azure-core/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: "com.android.library"
-
 version = "1.0.0-beta.1"
 
 android {
@@ -53,24 +51,4 @@ dependencies {
     implementation "javax.xml.stream:stax-api:$staxApiVersion" // https://stackoverflow.com/a/47371517/1473510
     testImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
     testImplementation "junit:junit:$jUnitVersion"
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = "sources"
-}
-
-// task javadoc(type: Javadoc) {
-//     source = android.sourceSets.main.java.srcDirs
-//     classpath += project.files(android.getBootClasspath().join(File.pathSeprator))
-// }
-
-// task javadocJar(type: Jar, dependsOn: javadoc) {
-//     classifier = 'javadoc'
-//     from javadoc.destinationDir
-// }
-
-artifacts {
-    archives sourcesJar
-//    archives javadocJar
 }

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -41,5 +41,6 @@ stages:
       ServiceDirectory: core
       Artifacts:
         - name: azure-core
+          groupId: com.azure.android
           safeName: azurecore
           stagingProfileId: 88192f04117501

--- a/sdk/storage/azure-storage-blob/build.gradle
+++ b/sdk/storage/azure-storage-blob/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: "com.android.library"
+version = "1.0.0-beta.1"
 
 android {
     compileSdkVersion 29

--- a/sdk/storage/azure-storage-blob/build.gradle
+++ b/sdk/storage/azure-storage-blob/build.gradle
@@ -1,38 +1,5 @@
 version = "1.0.0-beta.1"
-
-android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
-
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    lintOptions {
-        lintConfig file("$rootDir/eng/lint.xml")
-    }
-
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
-        }
-
-        debug {
-            debuggable true
-        }
-    }
-
-}
+group = "com.azure.android"
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -39,5 +39,6 @@ stages:
       ServiceDirectory: storage
       Artifacts:
         - name: azure-storage-blob
+          groupId: com.azure.android
           safeName: azurestorageblob
           stagingProfileId: 88192f04117501


### PR DESCRIPTION
This PR builds out the Gradle configuration to produce the various artifacts that we need to publish to Maven Central. It moves the common configuration down into the root ```build.gradle``` file. It adds logic to create the sources and javadoc bundles and spit out a *.pom file.

It then stages the files for each specified artifact into a folder which is then uploaded into the packages artifact. The idea is that if we have more then one artifact each set of files associated with the artifact will be in its own folder. This is in-line with something that we plan to do in the Java repo as well but it will happen first for Android.