### PR TITLE
Moved BiFunction interface into 'threeten' package.

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/BiFunction.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/BiFunction.java
@@ -3,12 +3,13 @@
  * Licensed under the MIT License.
  */
 
-package com.azure.android.core.internal.util.serializer;
+package com.azure.android.core.internal.util.serializer.threeten;
 
 /**
  * Represents a function that accepts two arguments and produces a result.
  */
-public interface BiFunction<T, U, R> {
+@FunctionalInterface
+interface BiFunction<T, U, R> {
     /**
      * Applies this function to the given arguments.
      *

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/DecimalUtils.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/DecimalUtils.java
@@ -16,8 +16,6 @@
 
 package com.azure.android.core.internal.util.serializer.threeten;
 
-import com.azure.android.core.internal.util.serializer.BiFunction;
-
 import org.threeten.bp.Instant;
 
 import java.math.BigDecimal;

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/DurationDeserializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/DurationDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.azure.android.core.internal.util.serializer.threeten;
 
-import com.azure.android.core.internal.util.serializer.BiFunction;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.JsonTokenId;

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/Function.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/Function.java
@@ -1,7 +1,16 @@
 package com.azure.android.core.internal.util.serializer.threeten;
 
+/**
+ * Represents a function that accepts one argument and produces a result.
+ */
 @FunctionalInterface
 interface Function<T, R> {
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t The function argument.
+     * @return The function result.
+     */
     R apply(T t);
 }
 

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/InstantDeserializer.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/InstantDeserializer.java
@@ -16,7 +16,6 @@
 
 package com.azure.android.core.internal.util.serializer.threeten;
 
-import com.azure.android.core.internal.util.serializer.BiFunction;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/ToIntFunction.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/ToIntFunction.java
@@ -3,15 +3,15 @@ package com.azure.android.core.internal.util.serializer.threeten;
 /**
  * Represents a function that accepts one argument and produces an {@code int} result.
  *
- * Very simple and stupid interface for representing functions f(T) &rarr; {@code int}.
+ * Very simple interface for representing functions f(T) &rarr; {@code int}.
  */
+@FunctionalInterface
 interface ToIntFunction<T> {
-
     /**
      * Applies this function to the given argument.
      *
-     * @param value the function argument
-     * @return the function result
+     * @param value The function argument.
+     * @return The function result.
      */
     int applyAsInt(T value);
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/ToLongFunction.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/util/serializer/threeten/ToLongFunction.java
@@ -3,15 +3,15 @@ package com.azure.android.core.internal.util.serializer.threeten;
 /**
  * Represents a function that accepts one argument and produces a {@code long} result.
  *
- * Very simple and stupid interface for representing functions f(T) &rarr; {@code long}.
+ * Very simple interface for representing functions f(T) &rarr; {@code long}.
  */
+@FunctionalInterface
 interface ToLongFunction<T> {
-
     /**
      * Applies this function to the given argument.
      *
-     * @param value the function argument
-     * @return the function result
+     * @param value The function argument.
+     * @return The function result.
      */
     long applyAsLong(T value);
 }


### PR DESCRIPTION
Moved the BiFunction functional interface into 'threeten' and made it package-private, since it's only used inside there. Additionally, I modified the JavaDoc and formatting of other functional interfaces' in the same package.