### PR TITLE
User agent interceptor fix

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/UserAgentInterceptor.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/UserAgentInterceptor.java
@@ -107,6 +107,9 @@ public class UserAgentInterceptor implements Interceptor {
                                 PlatformInformationProvider platformInformationProvider,
                                 ApplicationInformationProvider applicationInformationProvider,
                                 LocaleInformationProvider localeInformationProvider) {
+        sdkName = sdkName == null ? "" : sdkName;
+        sdkVersion = sdkVersion == null ? "" : sdkVersion;
+
         if (applicationId == null) {
             userAgent = String.format(
                 USER_AGENT_FORMAT,

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/UserAgentInterceptor.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/UserAgentInterceptor.java
@@ -17,6 +17,8 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
+// TODO: Truncate provided  application ID if too long.
+// TODO: Trim provided application ID.
 /**
  * Pipeline interceptor that adds "User-Agent" header to a request.
  * <p>
@@ -24,7 +26,8 @@ import okhttp3.Response;
  * <a href="https://azure.github.io/azure-sdk/general_azurecore.html#telemetry-policy">Azure Core: Telemetry policy</a>.
  */
 public class UserAgentInterceptor implements Interceptor {
-    private static final String USER_AGENT_HEADER = "User-Agent";
+    static final String USER_AGENT_HEADER = "User-Agent";
+
     private static final String DEFAULT_USER_AGENT = "azsdk-android";
 
     // From the design guidelines, the default user agent header format is:
@@ -150,7 +153,7 @@ public class UserAgentInterceptor implements Interceptor {
 
         return chain.proceed(request
             .newBuilder()
-            .addHeader("User-Agent", header)
+            .header("User-Agent", header)
             .build());
     }
 

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/UserAgentInterceptor.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/interceptor/UserAgentInterceptor.java
@@ -10,13 +10,14 @@ import androidx.annotation.NonNull;
 import com.azure.android.core.provider.ApplicationInformationProvider;
 import com.azure.android.core.provider.LocaleInformationProvider;
 import com.azure.android.core.provider.PlatformInformationProvider;
-import com.azure.android.core.util.CoreUtils;
 
 import java.io.IOException;
 
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import static com.azure.android.core.util.CoreUtils.isNullOrEmpty;
 
 /**
  * Pipeline interceptor that adds "User-Agent" header to a request.
@@ -120,7 +121,7 @@ public class UserAgentInterceptor implements Interceptor {
             getApplicationInfo(applicationInformationProvider),
             getLocaleInfo(localeInformationProvider));
 
-        if (CoreUtils.isNullOrEmpty(applicationId)) {
+        if (isNullOrEmpty(applicationId)) {
             userAgent = userAgentBase;
         } else {
             // Based on the design guidelines, applicationId must not contain a space.


### PR DESCRIPTION
Thanks for taking the time to contribute. Please take a moment to fill out the information below.

Fixes #199 & #200.

Changes Proposed in this pull request:
- Changed the intercept method to use header() instead of addHeader() so we only have one header named User-Agent at all times.
- Added checks and logic to make sure a user-provideed Application ID does not contain spaces and is not longer than 24 characters.
- Made additional changes to ensure user-provided values sdkName and sdkVersion are not included in the User Agent string when null.