### PR TITLE
Repair artifact publishing

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -19,15 +19,14 @@ jobs:
           tasks: 'sdk:${{parameters.ServiceDirectory}}:publish'
           publishJUnitResults: false
         displayName: Build and publish
-      - pwsh: |
-          Get-ChildItem sdk/${{parameters.ServiceDirectory}}/**/repo -Attributes Directory -Recurse |
-          ForEach-Object {
-            $Source = $_.FullName + '/*'
-            $Dest = '$(Build.ArtifactStagingDirectory)/' + $_.Parent.Parent.Name + '.zip'
-            Write-Host "Compressing $Source to $Dest"
-            Compress-Archive -Path $Source -DestinationPath $Dest
-          }
-        displayName: Stage artifacts for upload
+
+      - ${{ each artifact in parameters.Artifacts }}:
+        - pwsh: |
+            $artifactsToStage = Get-ChildItem sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/repo/**/${{artifact.name}}* -Recurse | Where-Object -FilterScript { $_.Name -match "(jar|pom|aar|module)$" }
+            $stagingLocation = New-Item -Type Directory -Path $(Build.ArtifactStagingDirectory) -Name ${{artifact.name}}
+            $artifactsToStage | Copy-Item -Destination $stagingLocation
+          displayName: Stage ${{artifact.name}} for upload
+
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: packages
         displayName: Upload artifacts

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -39,3 +39,6 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
     parameters:
       ServiceDirectory: core
+      Artifacts:
+        - name: azure-core
+          safeName: azurecore

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -37,3 +37,6 @@ stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
     parameters:
       ServiceDirectory: storage
+      Artifacts:
+        - name: azure-storage-blob
+          safeName: azurestorageblob


### PR DESCRIPTION
Updating artifact publishing to pick up the .module file from the repository so that it is passed along the pipeline for release. Moving back to lose files since that is what is required for the release pipeline. There will be another change in the release script to pick up the .module file as well (it might already do it).