### PR TITLE
Utils and DateTime changes

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/provider/AndroidPlatformInformationProvider.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/internal/provider/AndroidPlatformInformationProvider.java
@@ -6,7 +6,8 @@ package com.azure.android.core.internal.provider;
 import android.os.Build;
 
 import com.azure.android.core.provider.PlatformInformationProvider;
-import com.azure.android.core.util.CoreUtil;
+
+import static com.azure.android.core.util.CoreUtil.toTitleCase;
 
 /**
  * Provider that contains platform information extracted from the {@link Build} class.
@@ -18,9 +19,9 @@ public final class AndroidPlatformInformationProvider implements PlatformInforma
         String model = Build.MODEL;
 
         if (model.toLowerCase().startsWith(manufacturer.toLowerCase())) {
-            return CoreUtil.toTitleCase(model);
+            return toTitleCase(model).toString();
         } else {
-            return CoreUtil.toTitleCase(manufacturer) + " " + model;
+            return toTitleCase(manufacturer) + " " + model;
         }
     }
 

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Url.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Url.java
@@ -73,7 +73,7 @@ public final class Base64Url {
         if (bytes == null) {
             return new Base64Url((String) null);
         } else {
-            return new Base64Url(Base64Util.encodeURLWithoutPadding(bytes));
+            return new Base64Url(Base64Util.encodeUrlWithoutPadding(bytes));
         }
     }
 
@@ -96,7 +96,7 @@ public final class Base64Url {
             return null;
         }
 
-        return Base64Util.decodeURL(bytes);
+        return Base64Util.decodeUrl(bytes);
     }
 
     @Override

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Util.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/Base64Util.java
@@ -9,14 +9,18 @@ import android.util.Base64;
 /**
  * Utility for Base64 encoding and decoding.
  */
-public interface Base64Util {
+public final class Base64Util {
+    private Base64Util() {
+        // Empty constructor to prevent instantiation of this class.
+    }
+
     /**
      * Encodes a byte array to Base64.
      *
      * @param src The byte array to encode.
      * @return The Base64 encoded bytes.
      */
-    static byte[] encode(byte[] src) {
+    public static byte[] encode(byte[] src) {
         return src == null ? null : Base64.encode(src, Base64.DEFAULT);
     }
 
@@ -26,7 +30,7 @@ public interface Base64Util {
      * @param src The byte array to encode.
      * @return The Base64 URL encoded bytes.
      */
-    static byte[] encodeURLWithoutPadding(byte[] src) {
+    public static byte[] encodeUrlWithoutPadding(byte[] src) {
         int flags = Base64.URL_SAFE | Base64.NO_PADDING;
 
         return src == null ? null : Base64.encode(src, flags);
@@ -38,7 +42,7 @@ public interface Base64Util {
      * @param src The byte array to encode.
      * @return The Base64 encoded bytes.
      */
-    static String encodeToString(byte[] src) {
+    public static String encodeToString(byte[] src) {
         return src == null ? null : Base64.encodeToString(src, Base64.DEFAULT);
     }
 
@@ -48,7 +52,7 @@ public interface Base64Util {
      * @param encoded The byte array to decode.
      * @return The decoded byte array.
      */
-    static byte[] decode(byte[] encoded) {
+    public static byte[] decode(byte[] encoded) {
         return encoded == null ? null : Base64.decode(encoded, Base64.DEFAULT);
     }
 
@@ -58,7 +62,7 @@ public interface Base64Util {
      * @param src The byte array to decode.
      * @return The decoded byte array.
      */
-    static byte[] decodeURL(byte[] src) {
+    public static byte[] decodeUrl(byte[] src) {
         return src == null ? null : Base64.decode(src, Base64.URL_SAFE);
     }
 
@@ -68,7 +72,7 @@ public interface Base64Util {
      * @param src The string to decode.
      * @return The decoded byte array.
      */
-    static byte[] decodeURL(String src) {
+    public static byte[] decodeUrl(String src) {
         return src == null ? null : Base64.decode(src, Base64.URL_SAFE);
     }
 
@@ -78,7 +82,7 @@ public interface Base64Util {
      * @param encoded The string to decode.
      * @return The decoded byte array.
      */
-    static byte[] decodeString(String encoded) {
+    public static byte[] decodeString(String encoded) {
         return encoded == null ? null : Base64.decode(encoded, Base64.DEFAULT);
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/CoreUtil.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/CoreUtil.java
@@ -3,19 +3,25 @@
 
 package com.azure.android.core.util;
 
+import androidx.annotation.Nullable;
+
 import java.util.Map;
 
 /**
  * This interface contains static utility methods.
  */
-public interface CoreUtil {
+public final class CoreUtil {
+    private CoreUtil() {
+        // Empty constructor to prevent instantiation of this class.
+    }
+
     /**
      * Checks if the given character sequence is {@code null} or empty.
      *
      * @param charSequence Character sequence being checked for nullness or emptiness.
      * @return {@code true} if the character sequence is {@code null} or empty, {@code false} otherwise.
      */
-    static boolean isNullOrEmpty(CharSequence charSequence) {
+    public static boolean isNullOrEmpty(CharSequence charSequence) {
         return charSequence == null || charSequence.length() == 0;
     }
 
@@ -26,7 +32,8 @@ public interface CoreUtil {
      * @param pairs        Map containing which characters to look for and their replacements.
      * @return Character sequence where all keys in the given map have been replaced by their corresponding values.
      */
-    static CharSequence replace(CharSequence charSequence, Map<Character, CharSequence> pairs) {
+    @Nullable
+    public static CharSequence replace(CharSequence charSequence, Map<Character, CharSequence> pairs) {
         if (isNullOrEmpty(charSequence)) {
             if (pairs.containsKey(null)) {
                 return pairs.get(null);
@@ -54,9 +61,9 @@ public interface CoreUtil {
      * @param charSequence Character sequence to convert.
      * @return String where the first letter of each word has been converted to uppercase
      */
-    static String toTitleCase(CharSequence charSequence) {
+    public static CharSequence toTitleCase(CharSequence charSequence) {
         if (isNullOrEmpty(charSequence)) {
-            return charSequence.toString();
+            return charSequence;
         }
 
         StringBuilder stringBuilder = new StringBuilder();
@@ -77,6 +84,6 @@ public interface CoreUtil {
             stringBuilder.append(c);
         }
 
-        return stringBuilder.toString();
+        return stringBuilder;
     }
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/util/DateTimeRfc1123.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/util/DateTimeRfc1123.java
@@ -3,6 +3,8 @@
 
 package com.azure.android.core.util;
 
+import androidx.annotation.NonNull;
+
 import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.ZoneId;
 import org.threeten.bp.format.DateTimeFormatter;
@@ -34,7 +36,7 @@ public final class DateTimeRfc1123 {
      *
      * @param dateTime The DateTime object to wrap.
      */
-    public DateTimeRfc1123(OffsetDateTime dateTime) {
+    public DateTimeRfc1123(@NonNull OffsetDateTime dateTime) {
         this.dateTime = dateTime;
     }
 
@@ -43,7 +45,7 @@ public final class DateTimeRfc1123 {
      *
      * @param formattedString The DateTime string in RFC1123 format.
      */
-    public DateTimeRfc1123(String formattedString) {
+    public DateTimeRfc1123(@NonNull String formattedString) {
         dateTime = OffsetDateTime.parse(formattedString, DateTimeFormatter.RFC_1123_DATE_TIME);
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/interceptor/ResponseHeadersValidationInterceptor.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/interceptor/ResponseHeadersValidationInterceptor.java
@@ -3,7 +3,6 @@ package com.azure.android.storage.blob.interceptor;
 import androidx.annotation.NonNull;
 
 import com.azure.android.core.http.exception.HttpResponseException;
-import com.azure.android.core.util.CoreUtil;
 import com.azure.android.core.util.logging.ClientLogger;
 
 import java.io.IOException;
@@ -13,6 +12,8 @@ import java.util.Collection;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import static com.azure.android.core.util.CoreUtil.isNullOrEmpty;
 
 /**
  * Interceptor that validates that a collection of headers have consistent values between a request and a response.
@@ -69,7 +70,7 @@ public class ResponseHeadersValidationInterceptor implements Interceptor {
             String responseHeaderValue = response.header(headerName);
             String requestHeaderValue = request.header(headerName);
 
-            if (CoreUtil.isNullOrEmpty(responseHeaderValue) || !responseHeaderValue.equals(requestHeaderValue)) {
+            if (isNullOrEmpty(responseHeaderValue) || !responseHeaderValue.equals(requestHeaderValue)) {
                 String errorMessage = String.format(
                     "Unexpected header value. Expected response to echo '%s: %s'. Got value '%s'.",
                     headerName, requestHeaderValue, responseHeaderValue);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/interceptor/SasTokenCredentialInterceptor.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/interceptor/SasTokenCredentialInterceptor.java
@@ -3,7 +3,6 @@
 
 package com.azure.android.storage.blob.interceptor;
 
-import com.azure.android.core.util.CoreUtil;
 import com.azure.android.storage.blob.credentials.SasTokenCredential;
 
 import java.io.IOException;
@@ -12,6 +11,8 @@ import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import static com.azure.android.core.util.CoreUtil.isNullOrEmpty;
 
 /**
  *  Interceptor that append SAS token to the request Uri.
@@ -28,7 +29,7 @@ public class SasTokenCredentialInterceptor implements Interceptor {
         HttpUrl requestURL = chain.request().url();
 
         String encodedQuery = requestURL.encodedQuery();
-        if (!CoreUtil.isNullOrEmpty(encodedQuery)) {
+        if (!isNullOrEmpty(encodedQuery)) {
             encodedQuery += "&";
         }
 


### PR DESCRIPTION
- Changed the CoreUtils and Base64Util from interfaces to final classes with a private constructor.
- Made it so methods in CoreUtils are explicitly imported instead of inline imports to improve code readability (i.e. `CoreUtils.replace()` -> `replace()`).
- Changed DateTimeRfc1123 to use @NonNull for the parameters in its constructors.