### PR TITLE
Error notification, TransferInfo LiveData sharing and pause, resume support

### DIFF
--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -73,7 +73,9 @@ public class TransferClient {
      * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
      */
     public LiveData<TransferInfo> upload(String containerName, String blobName, File file) {
-        MutableLiveData<TransferIdOrError> idOrErrorChannel = new MutableLiveData<>();
+        TransferIdMappedToTransferInfo.Result result = TransferIdMappedToTransferInfo.create(context);
+        TransferIdMappedToTransferInfo.LiveDataPair liveDataPair = result.getLiveDataPair();
+        MutableLiveData<TransferIdOrError> idOrErrorChannel = liveDataPair.getTransferIdOrErrorLiveData();
         this.serialTaskExecutor.execute(() -> {
             try {
                 BlobUploadEntity blob = new BlobUploadEntity(containerName, blobName, file);
@@ -104,8 +106,7 @@ public class TransferClient {
                 idOrErrorChannel.postValue(TransferIdOrError.error(e));
             }
         });
-        return new TransferIdMappedToTransferInfo()
-            .getTransferInfoLiveData(context, idOrErrorChannel);
+        return liveDataPair.getTransferInfoLiveData();
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -8,10 +8,12 @@ import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Transformations;
 import androidx.work.Constraints;
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
@@ -37,12 +39,13 @@ public class TransferClient {
     // the default storage client for all transfers.
     private final StorageBlobClient blobClient;
     // the constraints to meet to run the transfers.
-    // currently hold the network type required for transfers.
     private final Constraints constraints;
     // the executor for internal book keeping.
     private SerialExecutor serialTaskExecutor;
     // reference to the database holding transfer entities.
     private final TransferDatabase db;
+    // track the active (not collected by GC) Transfers.
+    private final static TransferIdInfoLiveDataCache TRANSFER_ID_INFO_CACHE = new TransferIdInfoLiveDataCache();
 
     /**
      * Creates a {@link TransferClient} that uses provided {@link StorageBlobClient}
@@ -73,10 +76,10 @@ public class TransferClient {
      * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
      */
     public LiveData<TransferInfo> upload(String containerName, String blobName, File file) {
-        TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
-        TransferIdInfoLiveData.LiveDataPair liveDataPair = result.getLiveDataPair();
-        MutableLiveData<TransferIdOrError> idOrErrorChannel = liveDataPair.getTransferIdOrErrorLiveData();
+        // UI_Thread
+        final MutableLiveData<TransferIdOrError> idOrErrorChannel = new MutableLiveData<>();
         this.serialTaskExecutor.execute(() -> {
+            // BG_Thread
             try {
                 BlobUploadEntity blob = new BlobUploadEntity(containerName, blobName, file);
                 List<BlockUploadEntity> blocks
@@ -101,22 +104,230 @@ public class TransferClient {
                         ExistingWorkPolicy.KEEP,
                         uploadWorkRequest)
                     .enqueue();
-                idOrErrorChannel.postValue(TransferIdOrError.id(transferId));
+                idOrErrorChannel.postValue(TransferIdOrError.id(TransferIdOrError.Operation.UPLOAD_DOWNLOAD, transferId));
             } catch (Exception e) {
-                idOrErrorChannel.postValue(TransferIdOrError.error(e));
+                idOrErrorChannel.postValue(TransferIdOrError.error(TransferIdOrError.Operation.UPLOAD_DOWNLOAD, e));
             }
         });
-        return liveDataPair.getTransferInfoLiveData();
+        // UI_Thread
+        return toCachedTransferInfoLiveData(idOrErrorChannel, false);
     }
 
     /**
-     * Get the name for a unique transfer work.
+     * Pause a transfer identified by the given transfer id. The pause operation
+     * is a best-effort and it is possible that a transfer that is already executing
+     * may continue to transfer.
+     *
+     * Upon successful scheduling of the pause, any observer observing on
+     * {@link LiveData<TransferInfo>} for this transfer receives a {@link TransferInfo}
+     * event with state {@link TransferInfo.State#USER_PAUSED}.
+     *
+     * @param transferId the transfer id identifies the transfer to pause.
+     */
+    // P2: Currently no return value, evaluate any possible return value later.
+    public void pause(long transferId) {
+        // UI_Thread
+        final TransferIdInfoLiveData.TransferFlags transferFlags = TRANSFER_ID_INFO_CACHE.getTransferFlags(transferId);
+        this.serialTaskExecutor.execute(() -> {
+            // BG_Thread
+            try {
+                final PauseCheck pauseCheck = checkPauseable(transferId);
+                if (pauseCheck.canPause) {
+                    if (pauseCheck.isUpload) {
+                        db.uploadDao().updateUploadInterruptState(transferId, UploadInterruptState.USER_PAUSED);
+                    } else {
+                        throw new RuntimeException("Download::pause() NotImplemented");
+                    }
+                    if (transferFlags != null) {
+                        transferFlags.setUserPaused();
+                    }
+                    WorkManager
+                        .getInstance(context)
+                        .cancelUniqueWork(toTransferUniqueWorkName(transferId));
+                }
+            } catch (Exception e) {
+                Log.e(TAG, "Unable to schedule pause for the transfer:" + transferId, e);
+            }
+        });
+    }
+
+    /**
+     * Resume a transfer that was paused.
+     *
+     * @param @param transferId the transfer id identifies the transfer to resume.
+     * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
+     */
+    public LiveData<TransferInfo> resume(long transferId) {
+        // UI_Thread
+        final MutableLiveData<TransferIdOrError> idOrErrorChannel = new MutableLiveData<>();
+        this.serialTaskExecutor.execute(() -> {
+            // BG_Thread
+            try {
+                final ResumeCheck resumeCheck = checkResumeable(transferId, idOrErrorChannel);
+                if (resumeCheck.canResume) {
+                    StorageBlobClientsMap.put(transferId, blobClient);
+                    final OneTimeWorkRequest workRequest;
+                    if (resumeCheck.isUpload) {
+                        Data inputData = new Data.Builder()
+                            .putLong(UploadWorker.Constants.INPUT_BLOB_UPLOAD_ID_KEY, transferId)
+                            .build();
+                        workRequest = new OneTimeWorkRequest
+                            .Builder(UploadWorker.class)
+                            .setConstraints(constraints)
+                            .setInputData(inputData)
+                            .build();
+                        Log.v(TAG, "Upload::resume() Enqueuing UploadWorker: " + transferId);
+                    } else {
+                        throw new RuntimeException("Download::resume() NotImplemented");
+                    }
+                    //
+                    // Resume will resubmit the work to WorkManager with policy as KEEP.
+                    // which means if the work is already running then this resume() call
+                    // is NO-OP. We return the LiveData to the caller that can be observed
+                    // for TransferInfo events of the already running work.
+                    //
+                    WorkManager.getInstance(context)
+                        .beginUniqueWork(toTransferUniqueWorkName(transferId),
+                            ExistingWorkPolicy.KEEP,
+                            workRequest)
+                        .enqueue();
+                    idOrErrorChannel.postValue(TransferIdOrError.id(TransferIdOrError.Operation.RESUME, transferId));
+                }
+            } catch (Exception e) {
+                idOrErrorChannel.postValue(TransferIdOrError.error(TransferIdOrError.Operation.RESUME, e));
+            }
+        });
+        // UI_Thread
+        return toCachedTransferInfoLiveData(idOrErrorChannel, true);
+    }
+
+    /**
+     * Get unique name for a transfer work.
      *
      * @param transferId the transfer id
      * @return name for the transfer work
      */
     static String toTransferUniqueWorkName(long transferId) {
         return "azure_transfer_" + transferId;
+    }
+
+    /**
+     * Subscribe to a TransferIdOrError LiveData and transform that to TransferInfo LiveData.
+     *
+     * This method caches or uses cached {@link LiveData<TransferInfo>} to stream TransferInfo.
+     * If provided TransferIdOrError LiveData emit an error then cache won't be used.
+     *
+     * @param idOrErrorChannel the TransferIdOrError LiveData
+     * @param isResume true if the transfer id emitted by the TransferIdOrError LiveData identifies
+     *                 a transfer to be resumed, false for a new upload or download transfer.
+     * @return the TransferInfo LiveData
+     */
+    @MainThread
+    private LiveData<TransferInfo> toCachedTransferInfoLiveData(LiveData<TransferIdOrError> idOrErrorChannel,
+                                                                boolean isResume) {
+        // UI_Thread
+        return Transformations.switchMap(idOrErrorChannel, idOrError -> {
+            if (idOrError.isError()) {
+                final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
+                final TransferIdInfoLiveData.LiveDataPair pair = result.getLiveDataPair();
+                pair.getTransferIdOrErrorLiveData().setValue(idOrError);
+                return pair.getTransferInfoLiveData();
+            } else {
+                if (isResume) {
+                    // If application process already has a cached LiveData pair for the same transfer
+                    // then use it, otherwise create, cache and use.
+                    final TransferIdInfoLiveData.LiveDataPair pair
+                        = TRANSFER_ID_INFO_CACHE.getOrCreate(idOrError.getId(), context);
+                    pair.getTransferIdOrErrorLiveData().setValue(idOrError);
+                    return pair.getTransferInfoLiveData();
+                } else {
+                    // Create a transfer LiveData pair cache entry and use it.
+                    // Any future resume operation on the same transfer will use this pair as long as
+                    // both operations (upload_download and resume) happened in the same application
+                    // process and the cache entry is not GC-ed.
+                    final TransferIdInfoLiveData.LiveDataPair pair
+                        = TRANSFER_ID_INFO_CACHE.create(idOrError.getId(), context);
+                    pair.getTransferIdOrErrorLiveData().setValue(idOrError);
+                    return pair.getTransferInfoLiveData();
+                }
+            }
+        });
+    }
+
+    /**
+     * Do pre-validations to see a transfer can be resumed.
+     *
+     * @param transferId the transfer id to check for resume eligibility
+     * @param idOrErrorChannel the LiveData to post the error if the transfer cannot be resumed
+     * @return result of check
+     */
+    private ResumeCheck checkResumeable(long transferId, MutableLiveData<TransferIdOrError> idOrErrorChannel) {
+        // Check for Upload Record
+        BlobUploadEntity uploadBlob = db.uploadDao().getBlob(transferId);
+        if (uploadBlob != null) {
+            if (uploadBlob.state == BlobUploadState.FAILED) {
+                idOrErrorChannel.postValue(TransferIdOrError.alreadyInFailedStateError(transferId));
+                return new ResumeCheck(false, true);
+            } else if (uploadBlob.state == BlobUploadState.COMPLETED) {
+                idOrErrorChannel.postValue(TransferIdOrError.alreadyInCompletedStateError(transferId));
+                return new ResumeCheck(false, true);
+            }
+            return new ResumeCheck(true, true);
+        }
+        // TODO: Check for Download Record
+
+        // No upload or download transfer found.
+        idOrErrorChannel.postValue(TransferIdOrError.notFoundError(transferId));
+        return new ResumeCheck(false, false);
+    }
+
+    /** Result of {@link this#checkResumeable(long, MutableLiveData)}} **/
+    private static final class ResumeCheck {
+        // flag indicating whether transfer is resume-able or not.
+        final boolean canResume;
+        // if resume-able then this flag indicates the transfer type (upload|download)
+        final boolean isUpload;
+
+        ResumeCheck(boolean canResume, boolean isUpload) {
+            this.canResume = canResume;
+            this.isUpload = isUpload;
+        }
+    }
+
+    /**
+     * Do pre-validations to see a transfer can be paused.
+     *
+     * @param transferId the transfer id to check for pause eligibility
+     * @return result of check
+     */
+    private PauseCheck checkPauseable(long transferId) {
+        // Check for Upload Record
+        BlobUploadEntity blob = db.uploadDao().getBlob(transferId);
+        if (blob != null) {
+            if (blob.state == BlobUploadState.FAILED) {
+                return new PauseCheck(false, true);
+            } else if (blob.state == BlobUploadState.COMPLETED) {
+                return new PauseCheck(false, true);
+            }
+            return new PauseCheck(true, true);
+        }
+        // TODO: Check for Download Record
+
+        // No upload or download transfer found.
+        return new PauseCheck(false, false);
+    }
+
+    /** Result of {@link this#checkPauseable(long)}} **/
+    private static final class PauseCheck {
+        // flag indicating whether transfer is pause-able or not.
+        private final boolean canPause;
+        // if pause-able then this flag indicates the transfer type (upload|download)
+        final boolean isUpload;
+
+        private PauseCheck(boolean canPause, boolean isUpload) {
+            this.canPause = canPause;
+            this.isUpload = isUpload;
+        }
     }
 
     /**
@@ -187,6 +398,8 @@ public class TransferClient {
         /**
          * Sets the particular {@link NetworkType} the device should be in for running
          * the transfers.
+         *
+         * The default network type that {@link TransferClient} uses is {@link NetworkType#CONNECTED}.
          *
          * @param networkType The type of network required for transfers to run
          * @return Builder with provided network type set

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -73,8 +73,8 @@ public class TransferClient {
      * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
      */
     public LiveData<TransferInfo> upload(String containerName, String blobName, File file) {
-        TransferIdMappedToTransferInfo.Result result = TransferIdMappedToTransferInfo.create(context);
-        TransferIdMappedToTransferInfo.LiveDataPair liveDataPair = result.getLiveDataPair();
+        TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
+        TransferIdInfoLiveData.LiveDataPair liveDataPair = result.getLiveDataPair();
         MutableLiveData<TransferIdOrError> idOrErrorChannel = liveDataPair.getTransferIdOrErrorLiveData();
         this.serialTaskExecutor.execute(() -> {
             try {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveData.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveData.java
@@ -29,8 +29,8 @@ import java.util.List;
  * TransferInfo LiveData queries {@link WorkManager} for a LiveData that streams {@link WorkInfo} and transform
  * {@link WorkInfo} events to {@link TransferInfo} events.
  */
-final class TransferIdMappedToTransferInfo {
-    private static final String TAG = TransferIdMappedToTransferInfo.class.getSimpleName();
+final class TransferIdInfoLiveData {
+    private static final String TAG = TransferIdInfoLiveData.class.getSimpleName();
     // the input LiveData that receives the transfer id or error.
     private final MutableLiveData<TransferIdOrError> transferIdOrErrorLiveData = new MutableLiveData<>();
     // the output TransferInfo LiveData.
@@ -44,15 +44,15 @@ final class TransferIdMappedToTransferInfo {
     // flag to track whether the last event was a pause event.
     private boolean wasPaused;
 
-    private TransferIdMappedToTransferInfo() {}
+    private TransferIdInfoLiveData() {}
 
     @MainThread
-    static TransferIdMappedToTransferInfo.Result create(Context context) {
-        TransferIdMappedToTransferInfo transferIdInfoLiveData = new TransferIdMappedToTransferInfo();
+    static TransferIdInfoLiveData.Result create(Context context) {
+        TransferIdInfoLiveData transferIdInfoLiveData = new TransferIdInfoLiveData();
         return transferIdInfoLiveData.init(context);
     }
 
-    private TransferIdMappedToTransferInfo.Result  init(@NonNull Context context) {
+    private TransferIdInfoLiveData.Result  init(@NonNull Context context) {
         LiveData<WorkInfo> workInfoLiveData = this.mapInputTransferIdToWorkInfoLiveData(context);
         this.transferInfoLiveData.addSource(workInfoLiveData, workInfo -> {
             if (this.inputTransferIdOrError.isError()) {
@@ -322,7 +322,7 @@ final class TransferIdMappedToTransferInfo {
     }
 
     /**
-     * Type representing result of {@link TransferIdMappedToTransferInfo#create(Context)} method.
+     * Type representing result of {@link TransferIdInfoLiveData#create(Context)} method.
      */
     final static class Result {
         private final LiveDataPair liveDataPair;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveData.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveData.java
@@ -28,6 +28,15 @@ import java.util.List;
  * events describing current state of the transfer identified by the transfer id. Internally the source of the
  * TransferInfo LiveData queries {@link WorkManager} for a LiveData that streams {@link WorkInfo} and transform
  * {@link WorkInfo} events to {@link TransferInfo} events.
+ *
+ * Same transfer id can be set multiple times in the TransferIdOrError LiveData. Each such set results in querying
+ * {@link WorkManager} as described above. There can be active Observes for an original transfer when it is paused
+ * and later resumed by a different Worker. When possible we share the same LiveData pair between original transfer
+ * and it's resume. In such cases, the ability to set transfer id on the TransferIdOrError LiveData multiple times
+ * enables to transparently switch the Worker and keep any existing Observers of the original transfer to continue
+ * to receive the {@link TransferInfo} events.
+ *
+ * @see TransferIdInfoLiveDataCache (for LiveData pair sharing)
  */
 final class TransferIdInfoLiveData {
     private static final String TAG = TransferIdInfoLiveData.class.getSimpleName();
@@ -42,9 +51,9 @@ final class TransferIdInfoLiveData {
     private TransferIdOrError inputTransferIdOrError;
     // hold the state of the last WorkInfo received from Transfer Worker.
     private WorkInfo.State lastWorkInfoState;
-    // flag to track whether current event about to emit is fist event.
+    // flag to track whether current event about to emit from transferInfoLiveData is the first event.
     private boolean isFirstEvent = true;
-    // flag to track whether the last event was a pause event.
+    // flag to track whether the last emitted event from transferInfoLiveData was a pause event.
     private boolean wasPaused;
 
     private TransferIdInfoLiveData() {}
@@ -55,26 +64,34 @@ final class TransferIdInfoLiveData {
         return transferIdInfoLiveData.init(context);
     }
 
-    private TransferIdInfoLiveData.Result  init(@NonNull Context context) {
+    private TransferIdInfoLiveData.Result init(@NonNull Context context) {
+        // 1. Register mapping of transferId to LiveData<WorkInfo>
         LiveData<WorkInfo> workInfoLiveData = this.mapInputTransferIdToWorkInfoLiveData(context);
+        // 2. Register mapping of LiveData<WorkInfo> to LiveData<TransferInfo>
         this.transferInfoLiveData.addSource(workInfoLiveData, workInfo -> {
             if (this.inputTransferIdOrError.isError()) {
                 mapErrorFromTransferClient();
                 return;
             }
             if (workInfo == null) {
-                Log.v(TAG, "Received NULL WorkInfo event from WorkManager.");
+                Log.v(TAG, "Skipping Null 'WorkInfo' from WorkManager.");
                 return;
             }
+
             final WorkInfo.State lastWorkInfoState = getLastWorkInfoState();
-            if (lastWorkInfoState != null && lastWorkInfoState.isFinished()) {
-                Log.e(TAG, "Received an unexpected WorkInfo event from WorkManager after terminal state:"
-                    + workInfo.toString());
-                return;
+            if (lastWorkInfoState != null) {
+                if (lastWorkInfoState == WorkInfo.State.SUCCEEDED
+                    || lastWorkInfoState == WorkInfo.State.FAILED
+                    || (lastWorkInfoState == WorkInfo.State.CANCELLED && !this.wasPaused())) {
+                    Log.e(TAG, "Received an unexpected 'WorkInfo' from WorkManager after terminal state:"
+                        + workInfo.toString());
+                    return;
+                }
             }
+
             WorkInfo.State currentWorkInfoState = workInfo.getState();
             if (currentWorkInfoState == null) {
-                Log.v(TAG, "Received a WorkInfo event from WorkManager with NULL state.");
+                Log.v(TAG, "Skipping the 'WorkInfo' from WorkManager with Null state.");
                 return;
             }
             final long transferId = this.inputTransferIdOrError.getId();
@@ -84,6 +101,15 @@ final class TransferIdInfoLiveData {
                 this.setWasPaused(false);
                 this.transferInfoLiveData.setValue(TransferInfo.createStarted(transferId));
                 if (currentWorkInfoState == WorkInfo.State.ENQUEUED) {
+                    // the worker state can be WorkInfo.State.ENQUEUED in two cases -
+                    // 1. When work is scheduled for the first time.
+                    // 2. When work is paused by the system (e.g. no network).
+                    //
+                    // The #1 is mapped to TransferInfo.State.STARTED
+                    // and #2 is mapped to TransferInfo.State.SYSTEM_PAUSED
+                    //
+                    // The outer block handled #1 by sending TransferInfo.State.STARTED
+                    // hence returning.
                     return;
                 }
             }
@@ -92,9 +118,19 @@ final class TransferIdInfoLiveData {
                     this.transferInfoLiveData.setValue(TransferInfo.createResumed(transferId));
                 }
                 this.setWasPaused(false);
-                TransferInfo.Progress progress = tryGetProgress(workInfo);
+                TransferInfo.Progress progress = tryGetWorkerProgress(workInfo);
                 if (progress != null) {
                     this.transferInfoLiveData.setValue(TransferInfo.createProgress(transferId, progress));
+                }
+                return;
+            }
+            if (currentWorkInfoState == WorkInfo.State.CANCELLED) {
+                if (this.transferFlags.isUserPaused()) {
+                    this.setWasPaused(true);
+                    this.transferInfoLiveData.setValue(TransferInfo.createUserPaused(transferId));
+                } else {
+                    this.setWasPaused(false);
+                    this.transferInfoLiveData.setValue(TransferInfo.createCancelled(transferId));
                 }
                 return;
             }
@@ -125,6 +161,14 @@ final class TransferIdInfoLiveData {
      * @param transferIdOrError the transfer id or error
      */
     private void setTransferIdOrError(TransferIdOrError transferIdOrError) {
+        if (this.inputTransferIdOrError != null && !this.inputTransferIdOrError.isError()) {
+            if (this.inputTransferIdOrError.getId() != transferIdOrError.getId()) {
+                Log.e(TAG,
+                    "Cannot be associated to a different transferId."
+                        + " existing:" + this.inputTransferIdOrError.getId()
+                        + " new:" + transferIdOrError.getId());
+            }
+        }
         this.inputTransferIdOrError = transferIdOrError;
     }
 
@@ -147,8 +191,8 @@ final class TransferIdInfoLiveData {
     }
 
     /**
-     * Check whether the last {@link TransferInfo} event sent to the transfer Observer
-     * was a pause event {@link TransferInfo.State#SYSTEM_PAUSED}.
+     * Check whether the last {@link TransferInfo} event sent to the transfer Observer was
+     * a pause event i.e. {@link TransferInfo.State#SYSTEM_PAUSED} or {@link TransferInfo.State#USER_PAUSED}.
      *
      * @return true if the last event was a pause event, false otherwise.
      */
@@ -158,7 +202,7 @@ final class TransferIdInfoLiveData {
 
     /**
      * Set whether the current event about to send to the transfer Observer is a pause
-     * event {@link TransferInfo.State#SYSTEM_PAUSED} or not.
+     * event i.e. {@link TransferInfo.State#SYSTEM_PAUSED} or {@link TransferInfo.State#USER_PAUSED}.
      *
      * @param wasPaused true for pause event, false for non-pause event
      */
@@ -180,25 +224,25 @@ final class TransferIdInfoLiveData {
      * Store the current {@link WorkInfo.State} so that if needed it can be used while
      * preparing to send next event to the transfer Observer.
      *
-     * @param state the workinfo state
+     * @param state the WorkInfo state
      */
     private void setLastWorkInfoState(WorkInfo.State state) {
         this.lastWorkInfoState = state;
     }
 
     /**
-     * Get the LiveData that stream {@link WorkInfo} of a transfer worker.
+     * Get the LiveData that stream {@link WorkInfo} of a transfer worker corresponding to the input transfer id.
      *
      * This method uses {@link WorkManager} API to retrieve the LiveData of a transfer worker
-     * that is processing the transfer identified by the transfer id from transferIdOrErrorLiveData.
+     * that is processing the transfer identified by the transfer id emitted by {@code inputTransferIdOrErrorLiveData}.
      *
      * @param context the context
      * @return a LiveData of {@link WorkInfo}
      */
     private LiveData<WorkInfo> mapInputTransferIdToWorkInfoLiveData(Context context) {
-        LiveData<List<WorkInfo>> workInfosLiveData = Transformations
+        LiveData<List<WorkInfo>> workInfoListLiveData = Transformations
             .switchMap(
-                transferIdOrErrorLiveData,
+                this.transferIdOrErrorLiveData,
                 transferIdOrError -> {
                     setTransferIdOrError(transferIdOrError);
                     if (this.inputTransferIdOrError.isError()) {
@@ -216,7 +260,7 @@ final class TransferIdInfoLiveData {
                     }
                 }
             );
-        return Transformations.map(workInfosLiveData, workInfoList -> {
+        return Transformations.map(workInfoListLiveData, workInfoList -> {
             if (this.inputTransferIdOrError.isError()) {
                 // An error from TransferClient then emit null WorkInfo. The downstream should check error before
                 // start processing the WorkInfo.
@@ -241,10 +285,34 @@ final class TransferIdInfoLiveData {
      */
     private void mapErrorFromTransferClient() {
         if (this.inputTransferIdOrError.isError()) {
-            this.transferInfoLiveData.setValue(TransferInfo.createFailed(this.inputTransferIdOrError.getId(),
-                this.inputTransferIdOrError.getErrorMessage()));
-            this.setLastWorkInfoState(WorkInfo.State.FAILED);
-            return;
+            if (this.inputTransferIdOrError.getOperation() == TransferIdOrError.Operation.RESUME) {
+                if (this.inputTransferIdOrError.isNotFoundError()) {
+                    // Follow the same convention as WorkManager, i.e. if an Work is
+                    // unknown then emit null. Here application provided transfer id was not
+                    // identifying a transfer record.
+                    this.transferInfoLiveData.setValue(null);
+                    this.setLastWorkInfoState(WorkInfo.State.FAILED);
+                    return;
+                } else if (this.inputTransferIdOrError.isTerminatedError()) {
+                    TransferIdOrError.TransferInTerminatedStateError tError = this.inputTransferIdOrError.getError();
+                    if (tError.isCompleted()) {
+                        this.transferInfoLiveData
+                            .setValue(TransferInfo.createCompleted(this.inputTransferIdOrError.getId()));
+                        this.setLastWorkInfoState(WorkInfo.State.SUCCEEDED);
+                        return;
+                    }
+                }
+                this.transferInfoLiveData.setValue(TransferInfo.createFailed(this.inputTransferIdOrError.getId(),
+                    this.inputTransferIdOrError.getErrorMessage()));
+                this.setLastWorkInfoState(WorkInfo.State.FAILED);
+                return;
+            } else {
+                // TransferIdOrError.Operation.UPLOAD_DOWNLOAD
+                this.transferInfoLiveData.setValue(TransferInfo.createFailed(this.inputTransferIdOrError.getId(),
+                    this.inputTransferIdOrError.getErrorMessage()));
+                this.setLastWorkInfoState(WorkInfo.State.FAILED);
+                return;
+            }
         }
     }
 
@@ -252,9 +320,9 @@ final class TransferIdInfoLiveData {
      * Try to retrieve transfer progress from a {@link WorkInfo}.
      *
      * @param workInfo the work info from transfer Worker
-     * @return the progress description, null if description is not available in the workinfo.
+     * @return the progress description, null if description is not available in the WorkInfo.
      */
-    private static TransferInfo.Progress tryGetProgress(WorkInfo workInfo) {
+    private static TransferInfo.Progress tryGetWorkerProgress(WorkInfo workInfo) {
         Data progress = workInfo.getProgress();
         if (progress == null) {
             return null;
@@ -371,7 +439,39 @@ final class TransferIdInfoLiveData {
     /**
      * Instance of this type is used by TransferClient methods to set any flag that it want
      * TransferInfo LiveData source of the transfer to know.
+     *
+     * If a transfer has any 'active Observers' then that transfer's {@link TransferFlags}
+     * and LiveData pair (TransferInfo and TransferIdOrError LiveData) will be tracked
+     * in the {@link TransferIdInfoLiveDataCache} cache. By 'active Observers', we mean the
+     * Observers of TransferInfo LiveData those are not GC-ed yet hence the corresponding cache entry.
+     *
+     * The cache is shared across all {@link TransferClient} instances within a application process.
+     * This enables all Observers of a transfer [e.g. Observers of upload(tid: 1), Observers of
+     * resume(tid: 1)] to share the same source TransferInfo LiveData. Because of TransferInfo LiveData
+     * sharing, the effect of any flag set in {@link TransferFlags} by one {@link TransferClient} will be
+     * visible to Observers of same transfer in a different {@link TransferClient}.
      */
     final static class TransferFlags {
+        private volatile boolean userPaused;
+
+        /**
+         * Set the flag indicating that user paused a transfer by calling {@link TransferClient#pause(long)}.
+         */
+        void setUserPaused() {
+            this.userPaused = true;
+        }
+
+        /**
+         * Check whether the user paused the transfer in the current session.
+         * Note: this method reset the flag once called.
+         *
+         * @return true if user paused the transfer, false otherwise.
+         */
+        @MainThread
+        boolean isUserPaused() {
+            boolean b = this.userPaused;
+            this.userPaused = false;
+            return b;
+        }
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
@@ -10,17 +10,17 @@ import androidx.annotation.MainThread;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
-import com.azure.android.storage.blob.transfer.TransferIdInfoLiveData.TransferFlags;
-
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
 
+import com.azure.android.storage.blob.transfer.TransferIdInfoLiveData.TransferFlags;
+
 /**
  * A Hash table based cache, with each entry has transferId as 'key' and 'value' as reference
- * to {@link TransferFlags}, {@link LiveData< TransferIdOrError >} and weak reference to
- * {@link LiveData< TransferInfo >}.
+ * to {@link TransferFlags}, {@link LiveData<TransferIdOrError>} and weak reference to
+ * {@link LiveData<TransferInfo>}.
  *
  * The LiveData pair, i.e. TransferIdOrError LiveData and the TransferInfo LiveData
  * in a 'value' is related such that, when transferId set on TransferIdOrError LiveData
@@ -35,14 +35,16 @@ import java.util.HashMap;
  * methods to be accessible only from the main thread.
  *
  * The cache is designed to shared across all {@link TransferClient} instances within the
- * same application process.
+ * same application process. This enables all Observers of a transfer [e.g. Observers of
+ * upload(tid: 1), Observers of resume(tid: 1)] to listen to same TransferInfo LiveData,
+ * irrespective of the TransferClient they used to get the TransferInfo LiveData.
  *
  * The cache implementation assumes that the TransferIdOrError LiveData in the value
  * do not strongly refer to the TransferInfo LiveData in the same value either
  * directly or indirectly, since that will prevent the TransferIdOrError LiveData
  * from being collected.
  */
-final class TransferIdInfoLiveDataCache {
+final public class TransferIdInfoLiveDataCache {
     private static final String TAG = TransferIdInfoLiveDataCache.class.getSimpleName();
     // the internal map with each Entry in the format
     //  {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import android.content.Context;
+import android.util.Log;
+
+import androidx.annotation.MainThread;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.azure.android.storage.blob.transfer.TransferIdInfoLiveData.TransferFlags;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+
+/**
+ * A Hash table based cache, with each entry has transferId as 'key' and 'value' as reference
+ * to {@link TransferFlags}, {@link LiveData< TransferIdOrError >} and weak reference to
+ * {@link LiveData< TransferInfo >}.
+ *
+ * The LiveData pair, i.e. TransferIdOrError LiveData and the TransferInfo LiveData
+ * in a 'value' is related such that, when transferId set on TransferIdOrError LiveData
+ * then transferInfo of corresponding transfer will start streaming from TransferInfo
+ * LiveData.
+ *
+ * A cache entry will automatically be removed when the TransferInfo LiveData in
+ * that entry's value is no longer in ordinary use. The presence of weak reference to it
+ * in the cache entry will not prevent it being collected by the garbage collector.
+ *
+ * This cache is not synchronized explicitly but implicitly synchronized by enforcing its
+ * methods to be accessible only from the main thread.
+ *
+ * The cache is designed to shared across all {@link TransferClient} instances within the
+ * same application process.
+ *
+ * The cache implementation assumes that the TransferIdOrError LiveData in the value
+ * do not strongly refer to the TransferInfo LiveData in the same value either
+ * directly or indirectly, since that will prevent the TransferIdOrError LiveData
+ * from being collected.
+ */
+final class TransferIdInfoLiveDataCache {
+    private static final String TAG = TransferIdInfoLiveDataCache.class.getSimpleName();
+    // the internal map with each Entry in the format
+    //  {
+    //    key: transferId,
+    //    value: {
+    //        weak-ref: LiveData<TransferInfo>,
+    //        ref: LiveData<TransferIdOrError>,
+    //        ref: transferFlags
+    //    }
+    //  }
+    private final HashMap<Long, TransferInfoLiveDataWeakReference> map = new HashMap<>();
+    // Reference queue that GC enqueues the map value holding collected weak-ref.
+    private final ReferenceQueue<LiveData<TransferInfo>> queue = new ReferenceQueue<>();
+
+    /**
+     * Create a TransferIdOrError LiveData and a TransferInfo LiveData, associate it
+     * with given {@code transferId} parameter and store them in the cache. This method return these
+     * two LiveData in a {@Link TransferIdInfoLiveData#Pair}.
+     *
+     * When a transferId is set to TransferIdOrError LiveData then the TransferInfo LiveData stream
+     * TransferInfo of the Transfer identified by that transferId. When transferId is set to
+     * the TransferIdOrError LiveData it must be same as the transferId parameter.
+     *
+     * @param transferId the transferId to use as the key to identify the created LiveData
+     *                   instances.
+     * @param context the context
+     * @return the pair composing created {@code TransferIdOrError} LiveData and associated
+     * {@code TransferInfo} LiveData
+     */
+    @MainThread
+    public TransferIdInfoLiveData.LiveDataPair create(long transferId, Context context) {
+        this.expunge();
+        final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
+        final TransferIdInfoLiveData.LiveDataPair liveDataPair = result.getLiveDataPair();
+        this.map.put(transferId,
+            new TransferInfoLiveDataWeakReference(liveDataPair.getTransferInfoLiveData(),
+                liveDataPair.getTransferIdOrErrorLiveData(),
+                result.getTransferFlags(),
+                transferId,
+                this.queue));
+        return liveDataPair;
+    }
+
+    /**
+     * Check whether the TransferIdOrError LiveData and the TransferInfo LiveData that is identified
+     * by the given {@code transferId} key already exists in the cache, if it exists then return
+     * the two LiveData in a {@Link TransferIdInfoLiveData#Pair}. If it does not exists then create,
+     * store and return them, see {@link TransferIdInfoLiveDataCache#create(long, Context)}
+     * for more details.
+     *
+     * @param transferId the transferId to use as the key to identify the LiveData instances.
+     * @param context the context
+     * @return the pair composing created TransferIdOrError LiveData and associated TransferInfo LiveData
+     */
+    @MainThread
+    public TransferIdInfoLiveData.LiveDataPair getOrCreate(long transferId, Context context) {
+        this.expunge();
+        final TransferInfoLiveDataWeakReference ref = this.map.get(transferId);
+        if (ref != null) {
+            final LiveData<TransferInfo> transferInfoLiveData = ref.get();
+            if (transferInfoLiveData != null) {
+                return new TransferIdInfoLiveData.LiveDataPair(ref.getTransferIdLiveData(),
+                    transferInfoLiveData);
+            }
+        }
+        return create(transferId, context);
+    }
+
+    /**
+     * Get the Flag object that the TransferInfo LiveData source (that backs TransferInfo LiveData
+     * in the weak reference) check for any flag set by TransferClient methods on the transfer.
+     *
+     * @param transferId the transferId identifies the {@link TransferFlags} for the transfer
+     * @return the {@link TransferFlags}
+     */
+    @MainThread
+    public TransferIdInfoLiveData.TransferFlags getTransferFlags(long transferId) {
+        this.expunge();
+        final TransferInfoLiveDataWeakReference ref = this.map.get(transferId);
+        if (ref != null) {
+            return ref.getTransferFlags();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Expunges stale entries (containing already GCed {@code TransferInfo} LiveData) from the map.
+     */
+    @SuppressWarnings("unchecked")
+    private void expunge() {
+        int cnt = 0;
+        for (Reference<?> staledReference; (staledReference = this.queue.poll()) != null;) {
+            TransferInfoLiveDataWeakReference tReference = (TransferInfoLiveDataWeakReference) staledReference;
+            tReference.expunge();
+            this.map.remove(tReference.getTransferId());
+            cnt++;
+        }
+        Log.d(TAG, "RefCount:" + map.size() + " Collected:" + cnt);
+    }
+
+    /**
+     * Reference holding weak reference to TransferInfo LiveData and strong reference to TransferIdOrError
+     * LiveData and {@link TransferFlags}.
+     */
+    private static class TransferInfoLiveDataWeakReference extends WeakReference<LiveData<TransferInfo>> {
+        private final long transferId;
+        private MutableLiveData<TransferIdOrError> transferIdLiveData;
+        private TransferIdInfoLiveData.TransferFlags transferFlags;
+
+        /**
+         * Create a weak reference to TransferInfo LiveData.
+         *
+         * @param transferInfoLiveData the referent TransferInfo LiveData that this weak reference refer to
+         * @param transferIdLiveData the TransferIdOrError LiveData
+         * @param transferFlags the transfer flags object
+         * @param transferId the transfer id
+         * @param queue the reference queue for GC to enqueue this weak reference when once the
+         *              referent TransferInfo LiveData is collected
+         */
+        TransferInfoLiveDataWeakReference(LiveData<TransferInfo> transferInfoLiveData,
+                                          MutableLiveData<TransferIdOrError> transferIdLiveData,
+                                          TransferIdInfoLiveData.TransferFlags transferFlags,
+                                          long transferId,
+                                          ReferenceQueue<LiveData<TransferInfo>> queue) {
+            super(transferInfoLiveData, queue);
+            this.transferId = transferId;
+            this.transferIdLiveData = transferIdLiveData;
+            this.transferFlags = transferFlags;
+        }
+
+        /**
+         * Get the transfer id.
+         *
+         * @return the transfer id
+         */
+        long getTransferId() {
+            return this.transferId;
+        }
+
+        /**
+         * Get the transferId LiveData.
+         *
+         * When transferId set on this LiveData then transferInfo of corresponding
+         * transfer will start streaming by transferInfo LiveData.
+         *
+         * @return the transferId LiveData
+         */
+        MutableLiveData<TransferIdOrError> getTransferIdLiveData() {
+            return this.transferIdLiveData;
+        }
+
+        /**
+         * Get the Flag object that the TransferInfo LiveData source (that backs TransferInfo LiveData
+         * in the weak reference) check for any flag set by TransferClient methods on the transfer.
+         *
+         * @return the {@link TransferIdInfoLiveData.TransferFlags}
+         */
+        TransferIdInfoLiveData.TransferFlags getTransferFlags() {
+            return this.transferFlags;
+        }
+
+        /**
+         * null out any strong references.
+         */
+        void expunge() {
+            if (this.get() == null) {
+                this.transferIdLiveData = null;
+                this.transferFlags = null;
+            }
+        }
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
@@ -44,7 +44,7 @@ import com.azure.android.storage.blob.transfer.TransferIdInfoLiveData.TransferFl
  * directly or indirectly, since that will prevent the TransferIdOrError LiveData
  * from being collected.
  */
-final public class TransferIdInfoLiveDataCache {
+final class TransferIdInfoLiveDataCache {
     private static final String TAG = TransferIdInfoLiveDataCache.class.getSimpleName();
     // the internal map with each Entry in the format
     //  {
@@ -75,7 +75,7 @@ final public class TransferIdInfoLiveDataCache {
      * {@code TransferInfo} LiveData
      */
     @MainThread
-    public TransferIdInfoLiveData.LiveDataPair create(long transferId, Context context) {
+    TransferIdInfoLiveData.LiveDataPair create(long transferId, Context context) {
         this.expunge();
         final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
         final TransferIdInfoLiveData.LiveDataPair liveDataPair = result.getLiveDataPair();
@@ -100,7 +100,7 @@ final public class TransferIdInfoLiveDataCache {
      * @return the pair composing created TransferIdOrError LiveData and associated TransferInfo LiveData
      */
     @MainThread
-    public TransferIdInfoLiveData.LiveDataPair getOrCreate(long transferId, Context context) {
+    TransferIdInfoLiveData.LiveDataPair getOrCreate(long transferId, Context context) {
         this.expunge();
         final TransferInfoLiveDataWeakReference ref = this.map.get(transferId);
         if (ref != null) {
@@ -121,7 +121,7 @@ final public class TransferIdInfoLiveDataCache {
      * @return the {@link TransferFlags}
      */
     @MainThread
-    public TransferIdInfoLiveData.TransferFlags getTransferFlags(long transferId) {
+    TransferIdInfoLiveData.TransferFlags getTransferFlags(long transferId) {
         this.expunge();
         final TransferInfoLiveDataWeakReference ref = this.map.get(transferId);
         if (ref != null) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdMappedToTransferInfo.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdMappedToTransferInfo.java
@@ -99,8 +99,8 @@ final class TransferIdMappedToTransferInfo {
                 return;
             }
             if (currentWorkInfoState == WorkInfo.State.FAILED) {
-                // TODO: anuchan decide on error propagation
-                this.transferInfoLiveData.setValue(TransferInfo.createFailed(transferId));
+                this.transferInfoLiveData.setValue(TransferInfo.createFailed(transferId,
+                    tryGetWorkerErrorMessage(workInfo)));
                 return;
             }
             Log.e(TAG, "Received Unexpected WorkInfo event from WorkManager:" + workInfo.toString());
@@ -225,5 +225,19 @@ final class TransferIdMappedToTransferInfo {
         }
         long bytesTransferred = progress.getLong(UploadWorker.Constants.PROGRESS_BYTES_UPLOADED, -1);
         return new TransferInfo.Progress(totalBytes, bytesTransferred);
+    }
+
+    /**
+     * Try to retrieve transfer failure message from a {@link WorkInfo}.
+     *
+     * @param workInfo the work info object from transfer Worker
+     * @return the error message, null if it is not available in the work info object.
+     */
+    private static String tryGetWorkerErrorMessage(WorkInfo workInfo) {
+        Data data = workInfo.getOutputData();
+        if (data == null) {
+            return null;
+        }
+        return data.getString(UploadWorker.Constants.OUTPUT_ERROR_MESSAGE_KEY);
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
@@ -20,7 +20,7 @@ import java.lang.annotation.RetentionPolicy;
  * TransferClient methods encountered or could detect, this type is not used to channel the real time
  * error happened in the background worker.
  */
-public final class TransferIdOrError {
+final class TransferIdOrError {
     // the transfer operation type (upload_download, resume)
     private final @Operation int operation;
     // the transfer id.
@@ -35,7 +35,7 @@ public final class TransferIdOrError {
      * @param id the transfer id of a transfer
      * @return TransferIdOrError composing a valid transfer id
      */
-    public static TransferIdOrError id(@NonNull @Operation int operation, long id) {
+    static TransferIdOrError id(@NonNull @Operation int operation, long id) {
         return new TransferIdOrError(operation, id, null);
     }
 
@@ -112,7 +112,7 @@ public final class TransferIdOrError {
      *
      * @return the transfer id
      */
-    public long getId() {
+    long getId() {
         return this.id;
     }
 
@@ -121,7 +121,7 @@ public final class TransferIdOrError {
      *
      * @return true for error, false otherwise
      */
-    public boolean isError() {
+    boolean isError() {
         return this.error != null;
     }
 
@@ -202,7 +202,6 @@ public final class TransferIdOrError {
         Operation.RESUME,
     })
     @Retention(RetentionPolicy.SOURCE)
-    public
     @interface Operation {
         int UPLOAD_DOWNLOAD = 1;
         int RESUME = 2;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
@@ -9,7 +9,7 @@ import androidx.annotation.NonNull;
  * Package private.
  *
  * The type used by the methods in {@link TransferClient} (e.g. upload, download, resume) to
- * communicate data from background {@link SerialExecutor} to {@link TransferIdMappedToTransferInfo}.
+ * communicate data from background {@link SerialExecutor} to {@link TransferIdInfoLiveData}.
  *
  * The data includes the operation type, the actual transfer id of a transfer or an error indicating
  * the failure detected by TransferClient. Note that this type is used only to channel the error that

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Package private.
+ *
+ * The type used by the methods in {@link TransferClient} (e.g. upload, download, resume) to
+ * communicate data from background {@link SerialExecutor} to {@link TransferIdMappedToTransferInfo}.
+ *
+ * The data includes the operation type, the actual transfer id of a transfer or an error indicating
+ * the failure detected by TransferClient. Note that this type is used only to channel the error that
+ * TransferClient methods encountered or could detect, this type is not used to channel the real time
+ * error happened in the background worker.
+ */
+public final class TransferIdOrError {
+    // the transfer id.
+    private final long id;
+    // the error happened in TransferClient method when processing a transfer request.
+    private final Throwable error;
+
+    /**
+     * Create a TransferIdOrError object indicating a valid transfer id.
+     *
+     * @param id the transfer id of a transfer
+     * @return TransferIdOrError composing a valid transfer id
+     */
+    public static TransferIdOrError id(long id) {
+        return new TransferIdOrError(id, null);
+    }
+
+    /**
+     * Create a TransferIdOrError object indicating an error when performing
+     * a transfer operation otherwise would have yielded a transfer id.
+     *
+     * @param error the error happened in a TransferClient operation
+     * @return TransferIdOrError composing an error
+     */
+    static TransferIdOrError error(@NonNull Throwable error) {
+        return new TransferIdOrError(-1, error);
+    }
+
+    /**
+     * Get the transfer id.
+     *
+     * @return the transfer id
+     */
+    public long getId() {
+        return this.id;
+    }
+
+    /**
+     * Check whether this id indicate an error.
+     *
+     * @return true for error, false otherwise
+     */
+    public boolean isError() {
+        return this.error != null;
+    }
+
+    /**
+     * Get the error object.
+     *
+     * @param <T> the error type
+     * @return the error object
+     */
+    @SuppressWarnings({"unchecked"})
+    <T> T getError() {
+        if (isError()) {
+            return (T) this.error;
+        }
+        return null;
+    }
+
+    /**
+     * Get the error message describing book keeping error.
+     *
+     * @return the error message, null if there is no error
+     */
+    String getErrorMessage() {
+        if (isError()) {
+            return this.error.getMessage();
+        }
+        return null;
+    }
+
+    /**
+     * Create a TransferIdOrError object indicating an error when performing a transfer
+     * operation identified by the given id.
+     *
+     * @param id the id
+     * @param error the error happened in a TransferClient operation
+     * @return TransferIdOrError composing an error
+     */
+    private static TransferIdOrError error(long id, @NonNull Throwable error) {
+        return new TransferIdOrError(id, error);
+    }
+
+    /**
+     * Create a TransferIdOrError.
+     *
+     * @param id the transfer id of a transfer
+     * @param error the error happened during book keeping
+     */
+    private TransferIdOrError(long id, Throwable error) {
+        this.id = id;
+        this.error = error;
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdOrError.java
@@ -3,7 +3,11 @@
 
 package com.azure.android.storage.blob.transfer;
 
+import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * Package private.
@@ -17,6 +21,8 @@ import androidx.annotation.NonNull;
  * error happened in the background worker.
  */
 public final class TransferIdOrError {
+    // the transfer operation type (upload_download, resume)
+    private final @Operation int operation;
     // the transfer id.
     private final long id;
     // the error happened in TransferClient method when processing a transfer request.
@@ -25,22 +31,80 @@ public final class TransferIdOrError {
     /**
      * Create a TransferIdOrError object indicating a valid transfer id.
      *
+     * @param operation the transfer operation type - upload_download, resume
      * @param id the transfer id of a transfer
      * @return TransferIdOrError composing a valid transfer id
      */
-    public static TransferIdOrError id(long id) {
-        return new TransferIdOrError(id, null);
+    public static TransferIdOrError id(@NonNull @Operation int operation, long id) {
+        return new TransferIdOrError(operation, id, null);
     }
 
     /**
      * Create a TransferIdOrError object indicating an error when performing
      * a transfer operation otherwise would have yielded a transfer id.
      *
+     * @param operation the transfer operation type - upload_download, resume
      * @param error the error happened in a TransferClient operation
      * @return TransferIdOrError composing an error
      */
-    static TransferIdOrError error(@NonNull Throwable error) {
-        return new TransferIdOrError(-1, error);
+    static TransferIdOrError error(@NonNull @Operation int operation, @NonNull Throwable error) {
+        return new TransferIdOrError(operation, -1, error);
+    }
+
+    /**
+     * Create a TransferIdOrError object indicating that resume operation cannot be performed
+     * because provided id is not identifying a transfer.
+     *
+     * @param id the non-existing transfer id
+     * @return TransferIdOrError composing the error
+     */
+    static TransferIdOrError notFoundError(long id) {
+        return error(Operation.RESUME, id, new TransferNotFoundError(id));
+    }
+
+    /**
+     * Create a TransferIdOrError object indicating that a resume operation cannot be performed because
+     * the transfer with given id is is already Completed.
+     *
+     * @param id the transfer id
+     * @return TransferIdOrError composing the error
+     */
+    static TransferIdOrError alreadyInCompletedStateError(long id) {
+        return error(Operation.RESUME, id,
+            new TransferInTerminatedStateError(id, TransferInTerminatedStateError.State.COMPLETED));
+    }
+
+    /**
+     * Create a TransferIdOrError object indicating that the resume operation cannot be performed because
+     * transfer with given id is is already Failed.
+     *
+     * @param id the transfer id
+     * @return TransferIdOrError composing the error
+     */
+    static TransferIdOrError alreadyInFailedStateError(long id) {
+        return error(Operation.RESUME, id,
+            new TransferInTerminatedStateError(id, TransferInTerminatedStateError.State.FAILED));
+    }
+
+    /**
+     * Create a TransferIdOrError object indicating that the resume operation cannot be performed because
+     * transfer with given id is is already Cancelled.
+     *
+     * @param id the transfer id
+     * @return TransferIdOrError composing the error
+     */
+    static TransferIdOrError alreadyInCancelledStateError(long id) {
+        return error(Operation.RESUME, id,
+            new TransferInTerminatedStateError(id, TransferInTerminatedStateError.State.CANCELED));
+    }
+
+    /**
+     * Get the transfer operation type.
+     *
+     * @return the operation type
+     */
+    @Operation int getOperation() {
+        return this.operation;
     }
 
     /**
@@ -88,25 +152,128 @@ public final class TransferIdOrError {
     }
 
     /**
+     * Check whether this id indicate that some operation couldn't performed
+     * because the provided transfer id was not identifying a transfer.
+     *
+     * @return true for not-found error, false otherwise
+     */
+    boolean isNotFoundError() {
+        return this.error instanceof TransferNotFoundError;
+    }
+
+    /**
+     * Check whether this id indicate that some operation couldn't performed on a
+     * transfer because the transfer was already in terminal state.
+     *
+     * @return true for error indicating terminal transfer state, false otherwise
+     */
+    boolean isTerminatedError() {
+        return this.error instanceof TransferInTerminatedStateError;
+    }
+
+    /**
      * Create a TransferIdOrError object indicating an error when performing a transfer
      * operation identified by the given id.
      *
+     * @param operation the transfer operation type - upload_download, resume
      * @param id the id
      * @param error the error happened in a TransferClient operation
      * @return TransferIdOrError composing an error
      */
-    private static TransferIdOrError error(long id, @NonNull Throwable error) {
-        return new TransferIdOrError(id, error);
+    private static TransferIdOrError error(@NonNull @Operation int operation, long id, @NonNull Throwable error) {
+        return new TransferIdOrError(operation, id, error);
     }
 
     /**
      * Create a TransferIdOrError.
      *
+     * @param operation the transfer operation type - upload_download, resume
      * @param id the transfer id of a transfer
      * @param error the error happened during book keeping
      */
-    private TransferIdOrError(long id, Throwable error) {
+    private TransferIdOrError(@NonNull @Operation int operation, long id, Throwable error) {
+        this.operation = operation;
         this.id = id;
         this.error = error;
+    }
+
+    @IntDef({
+        Operation.UPLOAD_DOWNLOAD,
+        Operation.RESUME,
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public
+    @interface Operation {
+        int UPLOAD_DOWNLOAD = 1;
+        int RESUME = 2;
+    }
+
+    /**
+     * An internal exception indicating that a provided id is not identifying a transfer.
+     */
+    static class TransferNotFoundError extends Throwable {
+        private final long id;
+
+        /**
+         * Creates TransferNotFoundError.
+         *
+         * @param id the id that failed to resolve to a valid transfer
+         */
+        private TransferNotFoundError(long id) {
+            super("Transfer with id '" + id + "' is not found.");
+            this.id = id;
+        }
+
+        /**
+         * @return the id
+         */
+        long getId() {
+            return this.id;
+        }
+    }
+
+    /**
+     * An internal exception indicating that a transfer cannot be performed because the transfer
+     * is already in one of the terminal state.
+     */
+    static class TransferInTerminatedStateError extends Throwable {
+        // the transfer id.
+        private final long transferId;
+        // the terminal state the transfer is in.
+        private final @State int state;
+
+        private TransferInTerminatedStateError(long transferId, @NonNull @State int state) {
+            super("Transfer with id '" + transferId + "' is already in terminated stage.");
+            this.transferId = transferId;
+            this.state = state;
+        }
+
+        long getTransferId() {
+            return this.transferId;
+        }
+
+        boolean isCompleted() {
+            return this.state == State.COMPLETED;
+        }
+
+        boolean isFailed() {
+            return this.state == State.FAILED;
+        }
+
+        boolean isCancelled() {
+            return this.state == State.CANCELED;
+        }
+
+        @IntDef({
+            State.COMPLETED,
+            State.FAILED,
+            State.CANCELED
+        })
+        @Retention(RetentionPolicy.SOURCE)
+        private @interface State {
+            int COMPLETED = 1;
+            int FAILED = 2;
+            int CANCELED = 3;
+        }
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferInfo.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferInfo.java
@@ -26,6 +26,8 @@ public final class TransferInfo {
     private final @State int state;
     // the transfer progress.
     private final Progress progress;
+    // the string describing transfer failure reason
+    private final String errorMessage;
 
     /**
      * Create TransferInfo for a given state.
@@ -37,6 +39,7 @@ public final class TransferInfo {
         this.id = id;
         this.state = state;
         this.progress = null;
+        this.errorMessage = null;
     }
 
     /**
@@ -49,6 +52,20 @@ public final class TransferInfo {
         this.id = id;
         this.state = State.RECEIVED_PROGRESS;
         this.progress = progress;
+        this.errorMessage = null;
+    }
+
+    /**
+     * Create TransferInfo for {@link State#FAILED} state.
+     *
+     * @param id the transfer id
+     * @param errorMessage the string describing transfer failure reason
+     */
+    private TransferInfo(long id, String errorMessage) {
+        this.id = id;
+        this.state = State.FAILED;
+        this.progress = null;
+        this.errorMessage = errorMessage;
     }
 
     /**
@@ -107,12 +124,12 @@ public final class TransferInfo {
      * Create a {@link TransferInfo} indicating the transfer is failed.
      *
      * @param transferId the transfer id
+     * @param errorMessage the string describing transfer failure reason
      * @return {@link TransferInfo}
      */
-    static TransferInfo createFailed(long transferId) {
-        return new TransferInfo(transferId, State.FAILED);
+    static TransferInfo createFailed(long transferId, String errorMessage) {
+        return new TransferInfo(transferId, errorMessage);
     }
-
     /**
      * Get the transfer id.
      *
@@ -140,6 +157,17 @@ public final class TransferInfo {
      */
     public Progress getProgress() {
         return this.progress;
+    }
+
+    /**
+     * Get the error message. Note that error message is only available
+     * for the state ({@link State#FAILED}, for other states calling this
+     * method returns {@code null}.
+     *
+     * @return the string describing transfer failure reason
+     */
+    public String getErrorMessage() {
+        return this.errorMessage;
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferInfo.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferInfo.java
@@ -111,6 +111,16 @@ public final class TransferInfo {
     }
 
     /**
+     * Create a {@link TransferInfo} indicating that transfer is now paused by the user.
+     *
+     * @param transferId the transfer id
+     * @return {@link TransferInfo}
+     */
+    static TransferInfo createUserPaused(long transferId) {
+        return new TransferInfo(transferId, State.USER_PAUSED);
+    }
+
+    /**
      * Create a {@link TransferInfo} indicating the transfer is completed.
      *
      * @param transferId the transfer id
@@ -130,6 +140,17 @@ public final class TransferInfo {
     static TransferInfo createFailed(long transferId, String errorMessage) {
         return new TransferInfo(transferId, errorMessage);
     }
+
+    /**
+     * Create a {@link TransferInfo} indicating the transfer is cancelled.
+     *
+     * @param transferId the transfer id
+     * @return {@link TransferInfo}
+     */
+    static TransferInfo createCancelled(long transferId) {
+        return new TransferInfo(transferId, State.CANCELLED);
+    }
+
     /**
      * Get the transfer id.
      *
@@ -177,9 +198,11 @@ public final class TransferInfo {
         State.STARTED,
         State.RECEIVED_PROGRESS,
         State.SYSTEM_PAUSED,
+        State.USER_PAUSED,
         State.RESUMED,
         State.COMPLETED,
-        State.FAILED
+        State.FAILED,
+        State.CANCELLED
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface State {
@@ -199,17 +222,26 @@ public final class TransferInfo {
          */
         int SYSTEM_PAUSED = 3;
         /**
+         * Used to indicate that the transfer is paused by the user.
+         * The user has to request resume for a transfer in this state to continue.
+         */
+        int USER_PAUSED = 4;
+        /**
          * Used to indicate that the transfer that was paused is resumed.
          */
-        int RESUMED = 4;
+        int RESUMED = 5;
         /**
          * Used to indicate that the transfer has been completed.
          */
-        int COMPLETED = 5;
+        int COMPLETED = 6;
         /**
          * Used to indicate that the transfer has been failed.
          */
-        int FAILED = 6;
+        int FAILED = 7;
+        /**
+         * Used to indicate that the transfer is cancelled.
+         */
+        int CANCELLED = 8;
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/Util.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/Util.java
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import com.azure.android.core.internal.util.serializer.SerializerAdapter;
+import com.azure.android.core.internal.util.serializer.SerializerFormat;
+import com.azure.android.core.util.CoreUtil;
+import com.azure.android.storage.blob.models.BlobStorageException;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+import java.util.Objects;
+
+final class Util {
+    private Util() {
+        // Empty constructor to prevent instantiation of this class.
+    }
+
+    /**
+     * The exception from storage blob service usually adheres to a specific format
+     * described by {@link BlobServiceError}; this method tries to extract error
+     * details if an exception is in that format.
+     *
+     * @param exception the exception from storage service
+     * @return the extracted error as a string, null if the error cannot be parsed
+     */
+    static String tryGetNormalizedError(BlobStorageException exception) {
+        return BlobServiceError.tryGetNormalizedError(exception);
+    }
+
+    @JacksonXmlRootElement(localName = "Error")
+    private static class BlobServiceError {
+        @JsonProperty("Code")
+        private String code;
+
+        @JsonProperty("Message")
+        private String message;
+
+        private static String tryGetNormalizedError(BlobStorageException exception) {
+            Objects.requireNonNull(exception);
+            final String rawMessage = exception.getServiceMessage();
+            if (!CoreUtil.isNullOrEmpty(rawMessage)) {
+                final SerializerAdapter serializer = SerializerAdapter.createDefault();
+                try {
+                    final BlobServiceError blobServiceError = serializer.deserialize(rawMessage,
+                        BlobServiceError.class,
+                        SerializerFormat.XML);
+                    if (blobServiceError.code != null || blobServiceError.message != null) {
+                        final StringBuilder builder = new StringBuilder();
+                        builder.append(blobServiceError.code);
+                        if (builder.length() > 0) {
+                            builder.append(' ');
+                        }
+                        if (blobServiceError.message != null) {
+                            builder.append(blobServiceError.message.replace("\n", " "));
+                        }
+                        return builder.toString();
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
#### Features:

1. Adding support to promote errors from Background Worker and SerialExecutor to TransferInfo LiveData
    - From Background Worker https://github.com/Azure/azure-sdk-for-android/commit/e3f433ea459b818fdb53952102dbebed53e033ea
    - From SerialExecutor https://github.com/Azure/azure-sdk-for-android/pull/224/commits/7f18255f1119be4439ef13bd552a11bc07c23087
2. Adding support for weak-reference based cache to enable sharing of TransferInfo LiveData per transfer - commit https://github.com/Azure/azure-sdk-for-android/commit/68ee38e04e403bc8a2fb3984ecc39e19c8c2d2d4
3. Adding support for pause, resume infra and enabling it for upload - commit https://github.com/Azure/azure-sdk-for-android/commit/189d1be3d051aa840ae3d5e9b228b7fb59050d6f

#### Refactor:

1. Renaming TransferIdMappedToTransferInfo to TransferIdInfoLiveData - commit https://github.com/Azure/azure-sdk-for-android/commit/d696b38f95e3b44981986e36910786ba97b6bc5f