### PR TITLE
Fixed Gradle build issue for duplicated task names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,8 +158,10 @@ configure(subprojects.findAll { it.path.startsWith(':sdk:') && it.path.count(':'
     project.gradle.startParameter.taskNames.each { task ->
         task = task.split(':').last()
 
-        tasks.create(task) {
-            subprojects.each { dependsOn("$it.name:$task") }
+        if (tasks.findByPath(task) == null) {
+            tasks.create(task) {
+                subprojects.each { dependsOn("$it.name:$task") }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed an issue, with the help of @bsiegel, where Gradle would complain about not being able to create a task with a given name because it already existed.

