### PR TITLE
Support for providing Content URI of the content to be transferred

### DIFF
--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/MainActivity.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/MainActivity.java
@@ -53,7 +53,7 @@ public class MainActivity extends AppCompatActivity {
         this.uploadFileButton.setOnClickListener(v -> {
             Log.d("MainActivity", "setOnClickListener(): Upload file button.");
 
-            Intent chooseFile = new Intent(Intent.ACTION_GET_CONTENT);
+            Intent chooseFile = new Intent(Intent.ACTION_OPEN_DOCUMENT);
             chooseFile.setType("*/*");
             chooseFile = Intent.createChooser(chooseFile, "Select a file to upload.");
             startActivityForResult(chooseFile, PICK_FILE_RESULT_CODE);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
@@ -122,7 +122,7 @@ final class BlobDownloadEntity {
         this.blobName = blobName;
         this.blobSize = blobSize;
         this.contentUri = content.getUri().toString();
-        this.useContentResolver = content.isUseContentResolver();
+        this.useContentResolver = content.isUsingContentResolver();
         state = BlobTransferState.WAIT_TO_BEGIN;
         interruptState = TransferInterruptState.NONE;
     }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
@@ -50,7 +50,7 @@ final class BlobDownloadEntity {
     public long blobSize;
 
     /**
-     * The URI to the content to store the downloaded blob.
+     * The URI to the content where the downloaded blob will be stored.
      */
     @ColumnInfo(name = "content_uri")
     public String contentUri;
@@ -104,7 +104,7 @@ final class BlobDownloadEntity {
      * @param containerName The container name.
      * @param blobName The blob name.
      * @param blobSize The blob size.
-     * @param content describes the content to store the downloaded blob.
+     * @param content Describes the content where the downloaded blob will be stored.
      */
     @Ignore
     BlobDownloadEntity(String storageBlobClientId,

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
@@ -109,7 +109,7 @@ final class BlobUploadEntity {
 
         this.contentUri = content.getUri().toString();
         this.contentSize = content.getLength();
-        this.useContentResolver = content.isUseContentResolver();
+        this.useContentResolver = content.isUsingContentResolver();
 
         this.storageBlobClientId = storageBlobClientId;
         this.containerName = containerName;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
@@ -31,7 +31,7 @@ final class BlobUploadEntity {
     @ColumnInfo(name = "key")
     public Long key;
     /**
-     * The URI to the content to be uploaded as blob.
+     * The URI to the content to be uploaded as a blob.
      */
     @ColumnInfo(name = "content_uri")
     public String contentUri;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
@@ -95,21 +95,21 @@ final class BlobUploadEntity {
      * @param storageBlobClientId identifies the blob storage client to be used
      * @param containerName the container name
      * @param blobName the blob name
-     * @param contentDescription describes the content to be uploaded
+     * @param content describes the content to be read while uploading
      */
     @Ignore
     BlobUploadEntity(String storageBlobClientId,
                      String containerName,
                      String blobName,
-                     ContentDescription contentDescription) throws Throwable {
+                     ReadableContent content) throws Throwable {
         Objects.requireNonNull(storageBlobClientId);
         Objects.requireNonNull(containerName);
         Objects.requireNonNull(blobName);
-        Objects.requireNonNull(contentDescription);
+        Objects.requireNonNull(content);
 
-        this.contentUri = contentDescription.getUri().toString();
-        this.contentSize = contentDescription.getLength();
-        this.useContentResolver = contentDescription.isUseContentResolver();
+        this.contentUri = content.getUri().toString();
+        this.contentSize = content.getLength();
+        this.useContentResolver = content.isUseContentResolver();
 
         this.storageBlobClientId = storageBlobClientId;
         this.containerName = containerName;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlockDownloadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlockDownloadEntity.java
@@ -168,8 +168,8 @@ final class BlockDownloadEntity {
 
             blockDownloadEntities.add(blockDownloadEntity);
         } else {
-            long remainingLength = blobSize - blockSize;
-            long blobOffset = blockSize;
+            long remainingLength = blobSize;
+            long blobOffset = 0;
             int blocksCount = (int) Math.ceil(remainingLength / (double) blockSize);
 
             for (int i = 0; i < blocksCount; i++) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlockDownloadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlockDownloadEntity.java
@@ -13,7 +13,6 @@ import androidx.room.TypeConverters;
 
 import com.azure.android.core.util.Base64Util;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -62,10 +61,10 @@ final class BlockDownloadEntity {
     public String filePath;
 
     /**
-     * The offset in the file from which block contents starts.
+     * The offset in the blob from which block contents starts.
      */
-    @ColumnInfo(name = "blob_offset")
-    public long blobOffset;
+    @ColumnInfo(name = "block_offset")
+    public long blockOffset;
 
     /**
      * The block size in bytes.
@@ -104,17 +103,14 @@ final class BlockDownloadEntity {
      * Create a new BlockDownloadEntity to persist in local store.
      *
      * @param blockId The base64 block ID
-     * @param filePath The absolute path to the file that the block is a part of.
-     * @param blobOffset The offset in the file from which block contents starts.
+     * @param blockOffset The offset in the blob from which block contents starts.
      * @param blockSize The block size in bytes.
      */
-    private BlockDownloadEntity(String blockId, String filePath, long blobOffset, long blockSize) {
+    private BlockDownloadEntity(String blockId, long blockOffset, long blockSize) {
         Objects.requireNonNull(blockId);
-        Objects.requireNonNull(filePath);
 
         this.blockId = blockId;
-        this.filePath = filePath;
-        this.blobOffset = blobOffset;
+        this.blockOffset = blockOffset;
         this.blockSize = blockSize;
         this.state = BlockTransferState.WAIT_TO_BEGIN;
     }
@@ -150,19 +146,18 @@ final class BlockDownloadEntity {
     /**
      * Factory method to create a collection of {@link BlockDownloadEntity} for a blob.
      *
-     * @param blobSize The size of the blob being downloaded.
-     * @param blockSize Block size in bytes.
-     * @return A collection of {@link BlockDownloadEntity} describing each block of the blob.
+     * @param blobSize The size of the blob to download.
+     * @param blockSize The size of one block in the blob.
+     * @return A collection of {@link BlockDownloadEntity} describing each block of the blob to download.
      */
-    static List<BlockDownloadEntity> createEntitiesForBlob(File file, long blobSize, long blockSize) {
-        final String filePath = file.getAbsolutePath();
+    static List<BlockDownloadEntity> createBlockEntities(long blobSize,
+                                                         long blockSize) {
         final List<BlockDownloadEntity> blockDownloadEntities = new ArrayList<>();
 
         if (blobSize <= blockSize) {
             final String blockId = Base64Util.encodeToString(UUID.randomUUID().toString().getBytes(UTF_8));
 
             BlockDownloadEntity blockDownloadEntity = new BlockDownloadEntity(blockId,
-                filePath,
                 0,
                 (int) blobSize);
 
@@ -177,7 +172,6 @@ final class BlockDownloadEntity {
                 final long currentBlockLength = Math.min(blockSize, remainingLength);
 
                 BlockDownloadEntity blockDownloadEntity = new BlockDownloadEntity(blockId,
-                    filePath,
                     blobOffset,
                     currentBlockLength);
 
@@ -198,7 +192,7 @@ final class BlockDownloadEntity {
         builder.append(" key:").append(this.key)
             .append(" blobKey:").append(this.blobKey)
             .append(" filePath:").append(this.filePath)
-            .append(" blobOffset:").append(this.blobOffset)
+            .append(" blockOffset:").append(this.blockOffset)
             .append(" blockSize:").append(this.blockSize)
             .append(" state:").append(this.state);
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ContentDescription.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ContentDescription.java
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.UriPermission;
+import android.content.res.AssetFileDescriptor;
+import android.net.Uri;
+
+import androidx.annotation.MainThread;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Package private.
+ *
+ * A type that describes and enables operations on a content identifiable by a content URI.
+ * The actual content is the data that needs to be transferred to Azure Blob Storage.
+ */
+final class ContentDescription {
+    private final Context context;
+    private final Uri contentUri;
+    private final boolean useContentResolver;
+
+    /**
+     * Create ContentDescription representing a content in the device identified a given content URI.
+     *
+     * @param context the context
+     * @param contentUri the content URI identifying the content
+     * @param useContentResolver indicate whether to use {@link android.content.ContentResolver} to resolve
+     *                           the content URI
+     */
+    ContentDescription(Context context, String contentUri, boolean useContentResolver) {
+        this(context, Uri.parse(contentUri), useContentResolver);
+    }
+
+    /**
+     * Create ContentDescription representing a content in the device identified a given content URI.
+     *
+     * @param context the context
+     * @param contentUri the content URI identifying the content
+     * @param useContentResolver indicate whether to use {@link android.content.ContentResolver} to resolve
+     *                           the content URI
+     */
+    ContentDescription(Context context, Uri contentUri, boolean useContentResolver) {
+        this.context = context;
+        this.contentUri = contentUri;
+        this.useContentResolver = useContentResolver;
+    }
+
+    /**
+     * Get the {@link Uri} to the content to upload.
+     *
+     * @return the content URI
+     */
+    Uri getUri() {
+        return this.contentUri;
+    }
+
+    /**
+     * Check whether to use {@link android.content.ContentResolver} to resolve the content URI.
+     *
+     * @return true if resolving content URI requires content resolver.
+     */
+    boolean isUseContentResolver() {
+        return this.useContentResolver;
+    }
+
+    /**
+     * Attempt to take persistable read permission on the content.
+     *
+     * @throws Throwable if granting of read permission failed.
+     */
+    @MainThread
+    void takePersistableReadPermission() throws Throwable {
+        if (this.useContentResolver) {
+            this.context.getContentResolver()
+                .takePersistableUriPermission(contentUri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            checkPersistableReadGranted();
+        }
+    }
+
+    /**
+     * Get the total size of the content in bytes.
+     *
+     * @return the content size in bytes
+     * @throws Throwable if retrieval of content length fails
+     */
+    long getLength() throws Throwable {
+        final long contentLength;
+        if (this.useContentResolver) {
+            try (AssetFileDescriptor descriptor
+                     = this.context.getContentResolver().openAssetFileDescriptor(contentUri, "r")) {
+                contentLength = descriptor.getLength();
+            }
+        } else {
+            File file = new File(contentUri.getPath());
+            contentLength = file.length();
+        }
+        if (contentLength == -1) {
+            throw new Throwable("Unable to get size of the content '" + contentUri + "'.");
+        }
+        return contentLength;
+    }
+
+    /**
+     * Get a block of bytes from the content.
+     *
+     * @param blockOffset the start offset of the block
+     * @param blockSize the size of the block
+     * @return block of bytes in the range [blockOffset, blockOffset + blockSize]
+     * @throws Throwable if reading of block fails
+     */
+    byte [] getBlock(int blockOffset, int blockSize) throws Throwable {
+        if (this.useContentResolver) {
+            this.checkPersistableReadGranted();
+            try (AssetFileDescriptor descriptor
+                     = this.context.getContentResolver().openAssetFileDescriptor(this.contentUri, "r")) {
+                try (FileInputStream fileInputStream = descriptor.createInputStream()) {
+                    seek(fileInputStream, blockOffset);
+                    byte [] blockContent = new byte[blockSize];
+                    read(fileInputStream, blockContent);
+                    return blockContent;
+                }
+            }
+        } else {
+            File file = new File(this.contentUri.getPath());
+            try (FileInputStream fileInputStream = new FileInputStream(file)) {
+                seek(fileInputStream, blockOffset);
+                byte [] blockContent = new byte[blockSize];
+                read(fileInputStream, blockContent);
+                return blockContent;
+            }
+        }
+    }
+
+    /**
+     * Check a persistable read permission is granted on the content.
+     *
+     * @throws Throwable if permission is not granted
+     */
+    private void checkPersistableReadGranted() throws Throwable {
+        if (this.useContentResolver) {
+            final List<UriPermission> permissions = this.context.getContentResolver().getPersistedUriPermissions();
+            boolean grantedRead = false;
+            for (UriPermission permission : permissions) {
+                if (permission.isReadPermission()) {
+                    grantedRead = true;
+                    break;
+                }
+            }
+            if (!grantedRead) {
+                throw new Throwable("Read permission for the content '" + contentUri + "' is not granted or revoked.");
+            }
+        }
+    }
+
+    /**
+     * Seek the stream read cursor to the given position.
+     *
+     * @param stream the stream
+     * @param seekTo the seek position
+     * @throws IOException if seek fails
+     */
+    private static void seek(FileInputStream stream, long seekTo) throws IOException {
+        int skipped = 0;
+        while(skipped < seekTo) {
+            long m = stream.skip(seekTo - skipped);
+            if (m < 0) {
+                throw new IOException("FileInputStream::seek returns negative value.");
+            }
+            if (m == 0) {
+                if (stream.read() == -1) {
+                    return;
+                } else {
+                    skipped++;
+                }
+            } else {
+                skipped += m;
+            }
+        }
+    }
+
+    /**
+     * Read the stream content into a buffer starting from stream's read cursor position.
+     *
+     * @param stream the file stream
+     * @param buffer the output buffer
+     * @return the number of bytes read
+     * @throws IOException if read fails
+     */
+    private static int read(FileInputStream stream, byte [] buffer) throws IOException {
+        int bytesToRead = buffer.length;
+        int bytesRead = 0;
+        while (bytesRead < bytesToRead) {
+            int m = stream.read(buffer, bytesRead, bytesToRead - bytesRead);
+            if (m == -1) {
+                break;
+            }
+            bytesRead += m;
+        }
+        return bytesRead;
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ContentDescription.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ContentDescription.java
@@ -7,7 +7,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.UriPermission;
 import android.content.res.AssetFileDescriptor;
+import android.database.Cursor;
 import android.net.Uri;
+import android.provider.OpenableColumns;
 
 import androidx.annotation.MainThread;
 
@@ -94,10 +96,11 @@ final class ContentDescription {
     long getLength() throws Throwable {
         final long contentLength;
         if (this.useContentResolver) {
-            try (AssetFileDescriptor descriptor
-                     = this.context.getContentResolver().openAssetFileDescriptor(contentUri, "r")) {
-                contentLength = descriptor.getLength();
-            }
+            // https://developer.android.com/training/secure-file-sharing/retrieve-info
+            final Cursor cursor = this.context.getContentResolver().query(this.contentUri, null, null, null, null);
+            final int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
+            cursor.moveToFirst();
+            contentLength = cursor.getLong(sizeIndex);
         } else {
             File file = new File(contentUri.getPath());
             contentLength = file.length();

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
@@ -175,7 +175,7 @@ final class DownloadHandler extends Handler {
                     this.content.openForWrite(appContext);
                 } catch (Throwable t) {
                     this.transferHandlerListener.onError(new RuntimeException("Download operation with id '" + downloadId +
-                        "' is cannot be processed, failed to open the content to write.", t));
+                        "' cannot be processed, failed to open the content to write.", t));
                     getLooper().quit();
                 }
                 this.totalBytesDownloaded = this.db.downloadDao().getDownloadedBytesCount(downloadId);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
@@ -39,7 +39,6 @@ import java.util.Objects;
  */
 final class DownloadHandler extends Handler {
     private static final String TAG = DownloadHandler.class.getSimpleName();
-    private static final int BUFFER_SIZE = 2048; // Max allowed OkHttp buffer size.
 
     private final Context appContext;
     private final int blocksDownloadConcurrency;
@@ -205,9 +204,6 @@ final class DownloadHandler extends Handler {
             if (runningBlockDownloads.isEmpty()) {
                 db.downloadDao().updateBlobState(downloadId, BlobTransferState.COMPLETED);
 
-                Message nextMessage = DownloadHandlerMessage.createBlobDownloadCompletedMessage(DownloadHandler.this);
-                nextMessage.sendToTarget();
-
                 transferHandlerListener.onTransferProgress(blob.blobSize, blob.blobSize);
                 transferHandlerListener.onComplete();
                 getLooper().quit();
@@ -233,9 +229,6 @@ final class DownloadHandler extends Handler {
         Throwable downloadError = failedPair.first.getDownloadError();
 
         blob.setDownloadError(downloadError);
-
-        Message nextMessage = DownloadHandlerMessage.createBlobDownloadFailedMessage(DownloadHandler.this);
-        nextMessage.sendToTarget();
 
         transferHandlerListener.onError(downloadError);
         getLooper().quit();

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
@@ -4,6 +4,7 @@
 package com.azure.android.storage.blob.transfer;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
@@ -18,8 +19,6 @@ import com.azure.android.storage.blob.StorageBlobClient;
 import com.azure.android.storage.blob.models.BlobDownloadAsyncResponse;
 import com.azure.android.storage.blob.models.BlobRange;
 
-import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,6 +50,8 @@ final class DownloadHandler extends Handler {
     private BlobDownloadEntity blob;
     private long totalBytesDownloaded;
     private BlockDownloadRecordsEnumerator blocksItr;
+    // The content in the device to store the downloaded blob.
+    private WritableContent content;
     private StorageBlobClient blobClient;
 
     /**
@@ -167,6 +168,16 @@ final class DownloadHandler extends Handler {
                     .onError(new UnresolvedStorageBlobClientIdException(this.blob.storageBlobClientId));
                 this.getLooper().quit();
             } else {
+                this.content = new WritableContent(appContext,
+                    Uri.parse(this.blob.contentUri),
+                    this.blob.useContentResolver);
+                try {
+                    this.content.openForWrite(appContext);
+                } catch (Throwable t) {
+                    this.transferHandlerListener.onError(new RuntimeException("Download operation with id '" + downloadId +
+                        "' is cannot be processed, failed to open the content to write.", t));
+                    getLooper().quit();
+                }
                 this.totalBytesDownloaded = this.db.downloadDao().getDownloadedBytesCount(downloadId);
                 this.transferHandlerListener.onTransferProgress(blob.blobSize, totalBytesDownloaded);
 
@@ -204,6 +215,8 @@ final class DownloadHandler extends Handler {
             if (runningBlockDownloads.isEmpty()) {
                 db.downloadDao().updateBlobState(downloadId, BlobTransferState.COMPLETED);
 
+                closeContent();
+
                 transferHandlerListener.onTransferProgress(blob.blobSize, blob.blobSize);
                 transferHandlerListener.onComplete();
                 getLooper().quit();
@@ -226,8 +239,9 @@ final class DownloadHandler extends Handler {
             pair.second.cancel();
         }
 
-        Throwable downloadError = failedPair.first.getDownloadError();
+        closeContent();
 
+        Throwable downloadError = failedPair.first.getDownloadError();
         blob.setDownloadError(downloadError);
 
         transferHandlerListener.onError(downloadError);
@@ -244,6 +258,8 @@ final class DownloadHandler extends Handler {
             for (Pair<BlockDownloadEntity, ServiceCall> pair : runningBlockDownloads.values()) {
                 pair.second.cancel();
             }
+
+            closeContent();
 
             TransferInterruptState interruptState = db.downloadDao().getTransferInterruptState(downloadId);
 
@@ -278,7 +294,7 @@ final class DownloadHandler extends Handler {
                 blob.blobName,
                 null,
                 null,
-                new BlobRange(block.blobOffset, block.blockSize),
+                new BlobRange(block.blockOffset, block.blockSize),
                 null,
                 null,
                 null,
@@ -288,13 +304,12 @@ final class DownloadHandler extends Handler {
                 new com.azure.android.core.http.Callback<BlobDownloadAsyncResponse>() {
                     @Override
                     public void onResponse(BlobDownloadAsyncResponse response) {
-                        // TODO: Optimize to stream bytes instead of waiting for the whole response body. Need to
-                        //  keep track of how many bytes have been downloaded for the resume operation.
-                        try (RandomAccessFile randomAccessFile = new RandomAccessFile(blob.filePath, "rw")) {
-                            randomAccessFile.seek(block.blobOffset);
-                            randomAccessFile.write(response.getValue().bytes());
-                        } catch (IOException e) {
-                            onFailure(e);
+                        try {
+                            byte[] blockContent = response.getValue().bytes();
+                            content.writeBlock(block.blockOffset, blockContent);
+                        } catch (Throwable t) {
+                            onFailure(t);
+                            return;
                         }
 
                         Log.v(TAG, "downloadBlock(): Block downloaded:" + block.blockId + getThreadName());
@@ -320,6 +335,14 @@ final class DownloadHandler extends Handler {
                 });
 
             runningBlockDownloads.put(block.blockId, Pair.create(block, call));
+        }
+    }
+
+    private void closeContent() {
+        try {
+            this.content.close();
+        } catch (Throwable t) {
+            Log.i(TAG, "content::close()", t);
         }
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ReadableContent.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ReadableContent.java
@@ -32,8 +32,8 @@ final class ReadableContent {
      * Create ReadableContent representing a content in the device from which data can be read.
      *
      * @param context the context
-     * @param contentUri the content URI identifying the content
-     * @param useContentResolver indicate whether to use {@link android.content.ContentResolver} to resolve
+     * @param contentUri the URI identifying the content
+     * @param useContentResolver indicates whether to use {@link android.content.ContentResolver} to resolve
      *                           the content URI
      */
     ReadableContent(Context context, Uri contentUri, boolean useContentResolver) {
@@ -103,7 +103,7 @@ final class ReadableContent {
      *
      * @param blockOffset the start offset of the block
      * @param blockSize the size of the block
-     * @return block of bytes in the range [blockOffset, blockOffset + blockSize]
+     * @return an array of bytes taken from the content in the range [blockOffset, blockOffset + blockSize]
      * @throws IOException the IO error when attempting to read
      * @throws IllegalStateException if read permission is not granted or revoked
      */
@@ -111,8 +111,8 @@ final class ReadableContent {
         if (this.useContentResolver) {
             this.checkPersistableReadGranted();
             // ContentResolver::openFileDescriptor works but we use openAssetFileDescriptor
-            // so that providers that returns subsection of file gets supported.
-            // The "r" (read) mode is used so that the content providers that don't support write can also consumed.
+            // so that providers that return subsections of a file are supported.
+            // The "r" (read) mode is used so that the content providers that don't support write can also be consumed.
             try (AssetFileDescriptor descriptor
                      = this.context.getContentResolver().openAssetFileDescriptor(this.contentUri, "r")) {
                 try (FileInputStream fileInputStream = descriptor.createInputStream()) {
@@ -158,7 +158,7 @@ final class ReadableContent {
      * Seek the stream read cursor to the given position.
      *
      * @param stream the stream
-     * @param seekTo the seek position
+     * @param seekTo the stream position to seek
      * @throws IOException if seek fails
      */
     private static void seek(FileInputStream stream, long seekTo) throws IOException {
@@ -181,7 +181,7 @@ final class ReadableContent {
     }
 
     /**
-     * Read the stream content into a buffer starting from stream's read cursor position.
+     * Read the stream content into a buffer starting from the stream's read cursor position.
      *
      * @param stream the file stream
      * @param buffer the output buffer

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -74,7 +74,7 @@ public class TransferClient {
     }
 
     /**
-     * Upload content of a file.
+     * Upload the content of a file.
      *
      * @param storageBlobClientId the identifier of the blob storage client to use for the upload
      * @param containerName the container to upload the file to
@@ -94,9 +94,9 @@ public class TransferClient {
      * @param storageBlobClientId the identifier of the blob storage client to use for the upload
      * @param containerName the container to upload the file to
      * @param blobName the name of the target blob holding uploaded file
-     * @param contentUri uri to the Content to upload, the contentUri is resolved using
+     * @param contentUri URI to the Content to upload, the contentUri is resolved using
      *   {@link android.content.ContentResolver#openAssetFileDescriptor(Uri, String)}
-     *   with mode as "r". The supported  URI schemes are content:// file:// and android.resource://
+     *   with mode as "r". The supported URI schemes are: 'content://', 'file://' and 'android.resource://'
      * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
      */
     public LiveData<TransferInfo> upload(String storageBlobClientId, String containerName, String blobName, Uri contentUri) {
@@ -194,7 +194,7 @@ public class TransferClient {
      * @param storageBlobClientId the identifier of the blob storage client to use for the download
      * @param containerName The container to download the blob from.
      * @param blobName The name of the target blob to download.
-     * @param contentUri The uri to the local content to write the downloaded blob
+     * @param contentUri The URI to the local content where the downloaded blob will be stored.
      * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
      */
     public LiveData<TransferInfo> download(String storageBlobClientId, String containerName, String blobName, Uri contentUri) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -201,7 +201,7 @@ public class TransferClient {
         return download(storageBlobClientId,
             containerName,
             blobName,
-            new WritableContent(this.context, contentUri, false));
+            new WritableContent(this.context, contentUri, true));
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadHandler.java
@@ -149,7 +149,7 @@ final class UploadHandler extends Handler {
                 + this.uploadId + "' is already CANCELLED and cannot be RESTARTED or RESUMED."));
             this.getLooper().quit();
         } else if (this.blob.state == BlobTransferState.COMPLETED) {
-            this.transferHandlerListener.onTransferProgress(blob.fileSize, blob.fileSize);
+            this.transferHandlerListener.onTransferProgress(blob.contentSize, blob.contentSize);
             this.transferHandlerListener.onComplete();
             this.getLooper().quit();
         } else {
@@ -160,7 +160,7 @@ final class UploadHandler extends Handler {
                 this.getLooper().quit();
             } else {
                 this.totalBytesUploaded = this.db.uploadDao().getUploadedBytesCount(this.uploadId);
-                this.transferHandlerListener.onTransferProgress(blob.fileSize, totalBytesUploaded);
+                this.transferHandlerListener.onTransferProgress(blob.contentSize, totalBytesUploaded);
                 List<BlockTransferState> skip = new ArrayList();
                 skip.add(BlockTransferState.COMPLETED);
                 this.blocksItr = new BlockUploadRecordsEnumerator(this.db, this.uploadId, skip);
@@ -190,7 +190,7 @@ final class UploadHandler extends Handler {
         Pair<BlockUploadEntity, ServiceCall> p = this.runningBlockUploads.remove(blockId);
         BlockUploadEntity blockStaged = p.first;
         this.totalBytesUploaded += blockStaged.blockSize;
-        this.transferHandlerListener.onTransferProgress(this.blob.fileSize, this.totalBytesUploaded);
+        this.transferHandlerListener.onTransferProgress(this.blob.contentSize, this.totalBytesUploaded);
         List<BlockUploadEntity> blocks = blocksItr.getNext(1);
         if (blocks.isEmpty()) {
             if (runningBlockUploads.isEmpty()) {
@@ -226,7 +226,7 @@ final class UploadHandler extends Handler {
      * and terminates the handler.
      */
     private void handleCommitCompleted() {
-        this.transferHandlerListener.onTransferProgress(this.blob.fileSize, this.blob.fileSize);
+        this.transferHandlerListener.onTransferProgress(this.blob.contentSize, this.blob.contentSize);
         this.transferHandlerListener.onComplete();
         this.getLooper().quit();
     }
@@ -277,10 +277,23 @@ final class UploadHandler extends Handler {
         for (BlockUploadEntity block : blocks) {
             this.finalizeIfStopped();
             Log.v(TAG, "stageBlocks(): Uploading block:" + block.blockId + threadName());
+            byte [] blockContent;
+            try {
+                blockContent = block.getBlockContent(appContext);
+            } catch (Throwable t) {
+                Log.e(TAG,  "stageBlocks(): failure in reading content:" + block.blockId + threadName(), t);
+                db.uploadDao().updateBlockState(block.key, BlockTransferState.FAILED);
+                block.setStagingError(t);
+                Message nextMessage = UploadHandlerMessage
+                    .createStagingFailedMessage(UploadHandler.this, block.blockId);
+                nextMessage.sendToTarget();
+                return;
+            }
+
             ServiceCall call = this.blobClient.stageBlock(this.blob.containerName,
                 this.blob.blobName,
                 block.blockId,
-                block.getBlockContent(),
+                blockContent,
                 null, new com.azure.android.core.http.Callback<Void>() {
                     @Override
                     public void onResponse(Void response) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadHandler.java
@@ -287,7 +287,7 @@ final class UploadHandler extends Handler {
             try {
                 blockContent = content.readBlock(block.blockOffset, block.blockSize);
             } catch (Throwable t) {
-                Log.e(TAG,  "stageBlocks(): failure in reading content:" + block.blockId + threadName(), t);
+                Log.e(TAG,  "stageBlocks(): failure in reading content. Block id: " + block.blockId + ". Thread name: " + threadName(), t);
                 db.uploadDao().updateBlockState(block.key, BlockTransferState.FAILED);
                 block.setStagingError(t);
                 Message nextMessage = UploadHandlerMessage

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
@@ -92,7 +92,7 @@ final class WritableContent {
                 if (this.contentChannel == null) {
                     this.contentChannel = WriteToContentChannel.create(context, this.contentUri);
                 } else if (this.contentChannel.isClosed()) {
-                    throw new IllegalStateException("A closed Content Channel cannot be opened.");
+                    throw new IllegalStateException("A closed content Channel cannot be opened.");
                 }
             }
         }
@@ -117,7 +117,7 @@ final class WritableContent {
             // https://commonsware.com/blog/2016/03/15/how-consume-content-uri.html
             // Obtaining a RandomAccessFile requires the raw-path to the file backing the ContentUri.
             //
-            // So to write to Content, instead of RandomAccessFile we will use FileChannel, specifically
+            // So to write to content, instead of RandomAccessFile we will use FileChannel, specifically
             // we a shared instance of FileChannel to write the blocks downloaded by concurrent (OkHttp) threads.
             // Operations in FileChannel instance are concurrent safe.
             // https://developer.android.com/reference/java/nio/channels/FileChannel

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
@@ -29,7 +29,7 @@ final class WritableContent {
     private final Context context;
     private final Uri contentUri;
     private final boolean useContentResolver;
-    // Channel to write to the Content if ContentResolver is required to resolve the Content,
+    // Channel to write to the content if ContentResolver is required to resolve the content,
     // i.e. when useContentResolver == true
     private WriteToContentChannel contentChannel;
 
@@ -61,7 +61,7 @@ final class WritableContent {
      *
      * @return true if resolving content URI requires {@link android.content.ContentResolver}.
      */
-    boolean isUseContentResolver() {
+    boolean isUsingContentResolver() {
         return this.useContentResolver;
     }
 
@@ -175,7 +175,7 @@ final class WritableContent {
     }
 
     /**
-     * A Channel to write to a Content identified by a ContentUri.
+     * A Channel to write to a content identified by a ContentUri.
      */
     private static class WriteToContentChannel implements Closeable {
         private final Context context;
@@ -186,7 +186,7 @@ final class WritableContent {
         private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
         /**
-         * Creates WriteToContentChannel to write to the Content identified by the given ContentUri.
+         * Creates WriteToContentChannel to write to the content identified by the given ContentUri.
          *
          * @param context the context to resolve the content URI
          * @param contentUri the URI of the content to write to using this Channel.

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.UriPermission;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+
+import androidx.annotation.MainThread;
+
+import java.io.Closeable;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Package private.
+ *
+ * A type that describes a content in the device to which data can be written.
+ */
+final class WritableContent {
+    private final Context context;
+    private final Uri contentUri;
+    private final boolean useContentResolver;
+    // Channel to write to the Content if ContentResolver is required to resolve the Content,
+    // i.e. when useContentResolver == true
+    private WriteToContentChannel contentChannel;
+
+    /**
+     * Create WritableContent describing a content in the device on which data can be written.
+     *
+     * @param context the context
+     * @param contentUri the content URI identifying the content
+     * @param useContentResolver indicate whether to use {@link android.content.ContentResolver} to resolve
+     *                           the content URI
+     */
+    WritableContent(Context context, Uri contentUri, boolean useContentResolver) {
+        this.context = context;
+        this.contentUri = contentUri;
+        this.useContentResolver = useContentResolver;
+    }
+
+    /**
+     * Get the {@link Uri} to the content.
+     *
+     * @return the content URI
+     */
+    Uri getUri() {
+        return this.contentUri;
+    }
+
+    /**
+     * Check whether to use {@link android.content.ContentResolver} to resolve the content URI.
+     *
+     * @return true if resolving content URI requires content resolver.
+     */
+    boolean isUseContentResolver() {
+        return this.useContentResolver;
+    }
+
+    /**
+     * Attempt to take persistable write permission on the content.
+     *
+     * @throws IllegalStateException if write permission is not granted
+     */
+    @MainThread
+    void takePersistableWritePermission() throws IllegalStateException {
+        if (this.useContentResolver) {
+            this.context.getContentResolver()
+                .takePersistableUriPermission(this.contentUri, Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            checkPersistableWriteGranted(this.context, this.contentUri);
+        }
+    }
+
+    /**
+     * Open the content for writing.
+     *
+     * @throws IOException if fails to open underlying content resource in write mode
+     * @throws IllegalStateException if write permission to the content is not granted/revoked or
+     *     the channel was already opened and disposed
+     */
+    void openForWrite(Context context) throws IOException, IllegalStateException {
+        if (this.useContentResolver) {
+            synchronized (this) {
+                if (this.contentChannel == null) {
+                    this.contentChannel = WriteToContentChannel.create(context, this.contentUri);
+                } else if (this.contentChannel.isClosed()) {
+                    throw new IllegalStateException("A closed Content Channel cannot be opened.");
+                }
+            }
+        }
+    }
+
+    /**
+     * Write a block of bytes to the content.
+     *
+     * @param blockOffset the start offset to write the block to
+     * @param block the block of bytes to write
+     *
+     * @throws IOException the IO error when attempting to write
+     * @throws IllegalStateException if write permission is not granted or revoked
+     */
+    void writeBlock(long blockOffset, byte [] block) throws IOException, IllegalStateException {
+        if (this.useContentResolver) {
+            if (this.contentChannel == null) {
+                throw new IOException("openForWrite(..) must be called before invoking writeBlock(..).");
+            }
+            // When `useContentResolver` is true then ContentUri must be treated as an opaque handle
+            // and the raw-path must not be used.
+            // https://commonsware.com/blog/2016/03/15/how-consume-content-uri.html
+            // Obtaining a RandomAccessFile requires the raw-path to the file backing the ContentUri.
+            //
+            // So to write to Content, instead of RandomAccessFile we will use FileChannel, specifically
+            // we a shared instance of FileChannel to write the blocks downloaded by concurrent (OkHttp) threads.
+            // Operations in FileChannel instance are concurrent safe.
+            // https://developer.android.com/reference/java/nio/channels/FileChannel
+            //
+            // The FileChannel instance is obtained from a FileOutputStream for the ContentUri
+            // (see WriteToContentChannel). Only one instance of FileOutputStream can be opened
+            // in "write-mode" so we share the FileOutputStream instance and it's backing
+            // FileChannel instance.
+            // https://docs.oracle.com/javase/7/docs/api/java/io/FileOutputStream.html
+            //
+            this.contentChannel.writeBlock(blockOffset, block);
+        } else {
+            try (RandomAccessFile randomAccessFile = new RandomAccessFile(this.contentUri.getPath(), "rw")) {
+                randomAccessFile.seek(blockOffset);
+                randomAccessFile.write(block);
+            }
+        }
+    }
+
+    /**
+     * close the content.
+     *
+     * @throws IOException if close operation fails
+     */
+    void close() throws IOException {
+        if (this.useContentResolver) {
+            synchronized (this) {
+                if (this.contentChannel != null) {
+                    this.contentChannel.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * Check a persistable write permission is granted on the content.
+     *
+     * @param context the context to access content resolver
+     * @param contentUri the content uri
+     * @throws IllegalStateException if permission is not granted
+     */
+    private static void checkPersistableWriteGranted(Context context, Uri contentUri) throws IllegalStateException {
+        final List<UriPermission> permissions = context.getContentResolver().getPersistedUriPermissions();
+        boolean grantedWrite = false;
+        for (UriPermission permission : permissions) {
+            if (permission.isWritePermission()) {
+                grantedWrite = true;
+                break;
+            }
+        }
+
+        if (!grantedWrite) {
+            throw new IllegalStateException("Write permission for the content '" + contentUri + "' is not granted or revoked.");
+        }
+    }
+
+    /**
+     * A Channel to write to a Content identified by a ContentUri.
+     */
+    private static class WriteToContentChannel implements Closeable {
+        private final Context context;
+        private final Uri contentUri;
+        private final ParcelFileDescriptor parcelFileDescriptor;
+        private final FileOutputStream fileOutputStream;
+        private final FileChannel fileChannel;
+        private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+        /**
+         * Creates WriteToContentChannel to write to the Content identified by the given ContentUri.
+         *
+         * @param context the context to resolve the content uri
+         * @param contentUri the uri of the content to write to using this Channel.
+         *
+         * @throws IOException if fails to open underlying content resource in write mode
+         * @throws IllegalStateException if write permission to the content is not granted or revoked
+         */
+        static WriteToContentChannel create(Context context, Uri contentUri) throws IOException, IllegalStateException {
+            WritableContent.checkPersistableWriteGranted(context, contentUri);
+            return new WriteToContentChannel(context, contentUri);
+        }
+
+        /**
+         * Write a block of bytes to the Channel.
+         *
+         * @param blockOffset the start offset in the content to write the block
+         * @param block the block of bytes to write
+         * @throws IOException if write fails
+         * @throws IllegalStateException if write permission is not granted or revoked
+         */
+        void writeBlock(long blockOffset, byte [] block) throws IOException, IllegalStateException {
+            WritableContent.checkPersistableWriteGranted(this.context, this.contentUri);
+            this.fileChannel.write(ByteBuffer.wrap(block), blockOffset);
+        }
+
+        /**
+         * @return true if the Channel is closed
+         */
+        boolean isClosed() {
+            return this.isClosed.get();
+        }
+
+        /**
+         * Close the Channel.
+         *
+         * @throws IOException if close fails
+         */
+        @Override
+        public void close() throws IOException {
+            if (this.isClosed.getAndSet(true)) {
+                if (this.parcelFileDescriptor != null) {
+                    this.parcelFileDescriptor.close();
+                }
+                if (this.fileOutputStream != null) {
+                    this.fileOutputStream.close();
+                }
+                if (this.fileChannel != null) {
+                    this.fileChannel.close();
+                }
+            }
+        }
+
+        private WriteToContentChannel(Context context, Uri contentUri) throws IOException {
+            this.context = context;
+            this.contentUri = contentUri;
+            this.parcelFileDescriptor = context.getContentResolver().openFileDescriptor(this.contentUri, "w");
+            if (this.parcelFileDescriptor == null) {
+                throw new IOException("FileDescriptor for the content '" + this.contentUri + "' cannot be opened.");
+            }
+            this.fileOutputStream = new FileOutputStream(this.parcelFileDescriptor.getFileDescriptor());
+            this.fileChannel = this.fileOutputStream.getChannel();
+        }
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/WritableContent.java
@@ -37,8 +37,8 @@ final class WritableContent {
      * Create WritableContent describing a content in the device on which data can be written.
      *
      * @param context the context
-     * @param contentUri the content URI identifying the content
-     * @param useContentResolver indicate whether to use {@link android.content.ContentResolver} to resolve
+     * @param contentUri the URI identifying the content
+     * @param useContentResolver indicates whether to use {@link android.content.ContentResolver} to resolve
      *                           the content URI
      */
     WritableContent(Context context, Uri contentUri, boolean useContentResolver) {
@@ -59,7 +59,7 @@ final class WritableContent {
     /**
      * Check whether to use {@link android.content.ContentResolver} to resolve the content URI.
      *
-     * @return true if resolving content URI requires content resolver.
+     * @return true if resolving content URI requires {@link android.content.ContentResolver}.
      */
     boolean isUseContentResolver() {
         return this.useContentResolver;
@@ -82,7 +82,7 @@ final class WritableContent {
     /**
      * Open the content for writing.
      *
-     * @throws IOException if fails to open underlying content resource in write mode
+     * @throws IOException if not possible to open underlying content resource in write mode
      * @throws IllegalStateException if write permission to the content is not granted/revoked or
      *     the channel was already opened and disposed
      */
@@ -138,9 +138,9 @@ final class WritableContent {
     }
 
     /**
-     * close the content.
+     * Close the content.
      *
-     * @throws IOException if close operation fails
+     * @throws IOException if the close operation fails
      */
     void close() throws IOException {
         if (this.useContentResolver) {
@@ -153,10 +153,10 @@ final class WritableContent {
     }
 
     /**
-     * Check a persistable write permission is granted on the content.
+     * Check if persistable write permission is granted on the content.
      *
-     * @param context the context to access content resolver
-     * @param contentUri the content uri
+     * @param context the context to access {@link android.content.ContentResolver}
+     * @param contentUri the content URI
      * @throws IllegalStateException if permission is not granted
      */
     private static void checkPersistableWriteGranted(Context context, Uri contentUri) throws IllegalStateException {
@@ -188,10 +188,10 @@ final class WritableContent {
         /**
          * Creates WriteToContentChannel to write to the Content identified by the given ContentUri.
          *
-         * @param context the context to resolve the content uri
-         * @param contentUri the uri of the content to write to using this Channel.
+         * @param context the context to resolve the content URI
+         * @param contentUri the URI of the content to write to using this Channel.
          *
-         * @throws IOException if fails to open underlying content resource in write mode
+         * @throws IOException if failed to open the underlying content resource in write mode
          * @throws IllegalStateException if write permission to the content is not granted or revoked
          */
         static WriteToContentChannel create(Context context, Uri contentUri) throws IOException, IllegalStateException {


### PR DESCRIPTION
This PR add support to `TransferClient` to transfer content identified by content URI. 

Two internal abstractions - `ReadableContent` and `WritableContent` are introduced. These types exposes operations on Content - taking read & write permissions, checking granting state of read & write permissions, performing block read and write on Content, etc..

Both `upload` and `download` APIs now supports accepting content URI. The existing `upload`, `download` overloads that takes the `File` object are still there, which can be removed later if we identify that there are no use-case for it.

`Readable|WritableContent` also result in some code cleanup such as removing unnecessary columns from upload|download DB entities. An two issues identified during testing are fixed - 

(1).  Fixed block offset calculation error.
(2). Removed unnecessary message dispatching that won't be handled.

A good read on ContentURI: https://commonsware.com/blog/2016/03/15/how-consume-content-uri.html