### PR TITLE
Transfer apis in storage client

### DIFF
--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/BlobItemViewHolder.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/BlobItemViewHolder.java
@@ -18,8 +18,8 @@ import androidx.core.content.FileProvider;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.azure.android.storage.blob.StorageBlobClient;
 import com.azure.android.storage.blob.models.BlobItem;
-import com.azure.android.storage.blob.transfer.TransferClient;
 import com.azure.android.storage.sample.config.StorageConfiguration;
 
 import java.io.File;
@@ -33,7 +33,7 @@ public class BlobItemViewHolder extends RecyclerView.ViewHolder {
         this.blobName = itemView.findViewById(R.id.blob_name);
     }
 
-    public static BlobItemViewHolder create(ViewGroup parent, TransferClient transferClient) {
+    public static BlobItemViewHolder create(ViewGroup parent, StorageBlobClient storageBlobClient) {
         StorageConfiguration storageConfiguration = StorageConfiguration.create(parent.getContext());
         View blobItemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.blob_item, parent, false);
 
@@ -52,7 +52,7 @@ public class BlobItemViewHolder extends RecyclerView.ViewHolder {
             File file = new File(path, blobName);
 
             try {
-                transferClient.download(Constants.STORAGE_BLOB_CLIENT_ID, containerName, blobName, file)
+                storageBlobClient.download(parent.getContext(), containerName, blobName, file) // TODO:anuchan
                     .observe((LifecycleOwner) parent.getContext(), new TransferObserver() {
                         @Override
                         public void onStart(long transferId) {
@@ -61,7 +61,7 @@ public class BlobItemViewHolder extends RecyclerView.ViewHolder {
                             Button cancelButton = mainActivityView.findViewById(R.id.cancel_button);
 
                             cancelButton.setOnClickListener(v -> {
-                                transferClient.cancel(transferId);
+                                storageBlobClient.cancel(parent.getContext(), transferId);
                                 hideProgress(mainActivityView);
                                 Toast.makeText(parent.getContext(), "Download cancelled", Toast.LENGTH_SHORT)
                                     .show();

--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ContainerBlobsPagedListAdapter.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ContainerBlobsPagedListAdapter.java
@@ -7,19 +7,19 @@ import androidx.paging.PagedListAdapter;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.azure.android.storage.blob.StorageBlobClient;
 import com.azure.android.storage.blob.models.BlobItem;
-import com.azure.android.storage.blob.transfer.TransferClient;
 import com.azure.android.storage.sample.core.util.paging.PageLoadState;
 
 public class ContainerBlobsPagedListAdapter
         extends PagedListAdapter<BlobItem, RecyclerView.ViewHolder> {
     private final Runnable retryRunnable;
     private PageLoadState pageLoadState;
-    private TransferClient transferClient;
+    private StorageBlobClient storageBlobClient;
 
-    protected ContainerBlobsPagedListAdapter(TransferClient transferClient, Runnable retryRunnable) {
+    protected ContainerBlobsPagedListAdapter(StorageBlobClient storageBlobClient, Runnable retryRunnable) {
         super(new BlobItemComparer());
-        this.transferClient = transferClient;
+        this.storageBlobClient = storageBlobClient;
         this.retryRunnable = retryRunnable;
     }
 
@@ -28,7 +28,7 @@ public class ContainerBlobsPagedListAdapter
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         switch (viewType) {
             case R.layout.blob_item:
-                return BlobItemViewHolder.create(parent, transferClient);
+                return BlobItemViewHolder.create(parent, storageBlobClient);
             case R.layout.load_state_item:
                 return LoadingStateItemViewHolder.create(parent, this.retryRunnable);
             default:

--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ContainerBlobsPaginationRepository.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ContainerBlobsPaginationRepository.java
@@ -1,5 +1,7 @@
 package com.azure.android.storage.sample;
 
+import androidx.work.NetworkType;
+
 import com.azure.android.core.http.Callback;
 import com.azure.android.storage.blob.StorageBlobClient;
 import com.azure.android.storage.blob.models.BlobItem;
@@ -33,8 +35,9 @@ final class ContainerBlobsPaginationRepository
         final List<String> blobEndpointScopes = Arrays.asList(storageBlobUrl + ".default");
         this.authInterceptor = new TokenRequestObservableAuthInterceptor(blobEndpointScopes);
         //
-        this.storageBlobClient = storageBlobClient.newBuilder()
+        this.storageBlobClient = storageBlobClient.newBuilder("com.azure.android.storage.sample.download")
                 .setCredentialInterceptor(this.authInterceptor)
+                .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build();
     }
 

--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ListAndDownloadBlobsActivity.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ListAndDownloadBlobsActivity.java
@@ -20,7 +20,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.azure.android.storage.blob.StorageBlobClient;
 import com.azure.android.storage.blob.models.BlobItem;
-import com.azure.android.storage.blob.transfer.TransferClient;
 import com.azure.android.storage.sample.core.util.paging.PageLoadState;
 import com.azure.android.storage.sample.core.util.tokenrequest.TokenRequestObservable;
 import com.azure.android.storage.sample.core.util.tokenrequest.TokenRequestObserver;
@@ -86,15 +85,11 @@ public class ListAndDownloadBlobsActivity extends AppCompatActivity {
             });
 
         ContainerBlobsPaginationRepository repository = (ContainerBlobsPaginationRepository) this.viewModel.getRepository();
-
-        TransferClient transferClient = new TransferClient.Builder(getApplicationContext())
-            .addStorageBlobClient(Constants.STORAGE_BLOB_CLIENT_ID, repository.getStorageBlobClient())
-            .setRequiredNetworkType(androidx.work.NetworkType.CONNECTED)
-            .build();
+        StorageBlobClient storageBlobClient = repository.getStorageBlobClient();
 
         // Set up PagedList Adapter
         ContainerBlobsPagedListAdapter adapter =
-            new ContainerBlobsPagedListAdapter(transferClient, () -> this.viewModel.retry());
+            new ContainerBlobsPagedListAdapter(storageBlobClient, () -> this.viewModel.retry());
         this.recyclerView.setAdapter(adapter);
         this.viewModel.getPagedListObservable().observe(this, getPagedListObserver(adapter, this.recyclerView));
         this.viewModel.getLoadStateObservable().observe(this, getPageLoadStateObserver(adapter));

--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/UploadFileActivity.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/UploadFileActivity.java
@@ -11,9 +11,9 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.work.NetworkType;
 
 import com.azure.android.storage.blob.StorageBlobClient;
-import com.azure.android.storage.blob.transfer.TransferClient;
 import com.azure.android.storage.sample.config.StorageConfiguration;
 import com.azure.android.storage.sample.core.util.tokenrequest.TokenRequestObservable;
 import com.azure.android.storage.sample.core.util.tokenrequest.TokenRequestObservableAuthInterceptor;
@@ -84,9 +84,10 @@ public class UploadFileActivity extends AppCompatActivity {
         // Create a new StorageBlobClient from the existing client with different base URL and credentials but sharing
         // the underlying OkHttp Client.
         storageBlobClient = storageBlobClient
-            .newBuilder()
+            .newBuilder("com.azure.android.storage.sample.upload")
             .setBlobServiceUrl(storageConfiguration.getBlobServiceUrl())
             .setCredentialInterceptor(authInterceptor)
+            .setRequiredNetworkType(NetworkType.CONNECTED)
             .build();
     }
 
@@ -116,12 +117,7 @@ public class UploadFileActivity extends AppCompatActivity {
         Log.d("Upload Content", "File size: " + fileSize);
 
         try {
-            TransferClient transferClient = new TransferClient.Builder(getApplicationContext())
-                .addStorageBlobClient(Constants.STORAGE_BLOB_CLIENT_ID, storageBlobClient)
-                .setRequiredNetworkType(androidx.work.NetworkType.CONNECTED)
-                .build();
-
-            transferClient.upload(Constants.STORAGE_BLOB_CLIENT_ID, containerName, blobName, fileUri)
+            storageBlobClient.upload(getApplicationContext(), containerName, blobName, fileUri)
                 .observe(this, new TransferObserver() {
                     @Override
                     public void onStart(long transferId) {

--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/di/StorageBlobModule.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/di/StorageBlobModule.java
@@ -18,7 +18,7 @@ public class StorageBlobModule {
     @Provides
     @Singleton
     StorageBlobClient provideStorageBlobClient() {
-        return new StorageBlobClient.Builder()
+        return new StorageBlobClient.Builder("com.azure.android.storage.sample")
                 .setBlobServiceUrl(this.baseUrl)
                 .build();
     }

--- a/sdk/storage/azure-storage-blob/schema/com.azure.android.storage.blob.transfer.TransferDatabase/1.json
+++ b/sdk/storage/azure-storage-blob/schema/com.azure.android.storage.blob.transfer.TransferDatabase/1.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "830a884e1c966dfb60c1359edba6a1cd",
+    "identityHash": "676acd791313226090eed7e02bd3cc73",
     "entities": [
       {
         "tableName": "blobuploads",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `file_path` TEXT, `file_size` INTEGER NOT NULL, `storage_blob_client_id` TEXT, `container_name` TEXT, `blob_name` TEXT, `blob_upload_state` INTEGER, `transfer_interrupt_state` INTEGER)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `content_uri` TEXT, `content_size` INTEGER NOT NULL, `use_content_resolver` INTEGER NOT NULL, `storage_blob_client_id` TEXT, `container_name` TEXT, `blob_name` TEXT, `blob_upload_state` INTEGER, `transfer_interrupt_state` INTEGER, `required_network_type` INTEGER, `requires_charging` INTEGER NOT NULL, `requires_device_idle` INTEGER NOT NULL, `requires_battery_not_low` INTEGER NOT NULL, `requires_storage_not_low` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "key",
@@ -15,14 +15,20 @@
             "notNull": false
           },
           {
-            "fieldPath": "filePath",
-            "columnName": "file_path",
+            "fieldPath": "contentUri",
+            "columnName": "content_uri",
             "affinity": "TEXT",
             "notNull": false
           },
           {
-            "fieldPath": "fileSize",
-            "columnName": "file_size",
+            "fieldPath": "contentSize",
+            "columnName": "content_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useContentResolver",
+            "columnName": "use_content_resolver",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -55,6 +61,36 @@
             "columnName": "transfer_interrupt_state",
             "affinity": "INTEGER",
             "notNull": false
+          },
+          {
+            "fieldPath": "constraintsColumn.requiredNetworkType",
+            "columnName": "required_network_type",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresCharging",
+            "columnName": "requires_charging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresDeviceIdle",
+            "columnName": "requires_device_idle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresBatteryNotLow",
+            "columnName": "requires_battery_not_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresStorageNotLow",
+            "columnName": "requires_storage_not_low",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -68,7 +104,7 @@
       },
       {
         "tableName": "blockuploads",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `blob_key` INTEGER NOT NULL, `file_path` TEXT, `file_offset` INTEGER NOT NULL, `block_size` INTEGER NOT NULL, `block_id` TEXT, `block_upload_state` INTEGER, FOREIGN KEY(`blob_key`) REFERENCES `blobuploads`(`key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `blob_key` INTEGER NOT NULL, `block_offset` INTEGER NOT NULL, `block_size` INTEGER NOT NULL, `block_id` TEXT, `block_upload_state` INTEGER, FOREIGN KEY(`blob_key`) REFERENCES `blobuploads`(`key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "key",
@@ -83,14 +119,8 @@
             "notNull": true
           },
           {
-            "fieldPath": "filePath",
-            "columnName": "file_path",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "fileOffset",
-            "columnName": "file_offset",
+            "fieldPath": "blockOffset",
+            "columnName": "block_offset",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -145,7 +175,7 @@
       },
       {
         "tableName": "blobdownloads",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `container_name` TEXT, `blob_name` TEXT, `blob_size` INTEGER NOT NULL, `file_path` TEXT, `storage_blob_client_id` TEXT, `blob_download_state` INTEGER, `transfer_interrupt_state` INTEGER)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `container_name` TEXT, `blob_name` TEXT, `blob_size` INTEGER NOT NULL, `content_uri` TEXT, `use_content_resolver` INTEGER NOT NULL, `storage_blob_client_id` TEXT, `blob_download_state` INTEGER, `transfer_interrupt_state` INTEGER, `required_network_type` INTEGER, `requires_charging` INTEGER NOT NULL, `requires_device_idle` INTEGER NOT NULL, `requires_battery_not_low` INTEGER NOT NULL, `requires_storage_not_low` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "key",
@@ -172,10 +202,16 @@
             "notNull": true
           },
           {
-            "fieldPath": "filePath",
-            "columnName": "file_path",
+            "fieldPath": "contentUri",
+            "columnName": "content_uri",
             "affinity": "TEXT",
             "notNull": false
+          },
+          {
+            "fieldPath": "useContentResolver",
+            "columnName": "use_content_resolver",
+            "affinity": "INTEGER",
+            "notNull": true
           },
           {
             "fieldPath": "storageBlobClientId",
@@ -194,6 +230,36 @@
             "columnName": "transfer_interrupt_state",
             "affinity": "INTEGER",
             "notNull": false
+          },
+          {
+            "fieldPath": "constraintsColumn.requiredNetworkType",
+            "columnName": "required_network_type",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresCharging",
+            "columnName": "requires_charging",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresDeviceIdle",
+            "columnName": "requires_device_idle",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresBatteryNotLow",
+            "columnName": "requires_battery_not_low",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "constraintsColumn.requiresStorageNotLow",
+            "columnName": "requires_storage_not_low",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -207,7 +273,7 @@
       },
       {
         "tableName": "blockdownloads",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `blob_key` INTEGER NOT NULL, `file_path` TEXT, `blob_offset` INTEGER NOT NULL, `block_size` INTEGER NOT NULL, `block_id` TEXT, `block_download_state` INTEGER, FOREIGN KEY(`blob_key`) REFERENCES `blobdownloads`(`key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` INTEGER PRIMARY KEY AUTOINCREMENT, `blob_key` INTEGER NOT NULL, `file_path` TEXT, `block_offset` INTEGER NOT NULL, `block_size` INTEGER NOT NULL, `block_id` TEXT, `block_download_state` INTEGER, FOREIGN KEY(`blob_key`) REFERENCES `blobdownloads`(`key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "key",
@@ -228,8 +294,8 @@
             "notNull": false
           },
           {
-            "fieldPath": "blobOffset",
-            "columnName": "blob_offset",
+            "fieldPath": "blockOffset",
+            "columnName": "block_offset",
             "affinity": "INTEGER",
             "notNull": true
           },
@@ -286,7 +352,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '830a884e1c966dfb60c1359edba6a1cd')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '676acd791313226090eed7e02bd3cc73')"
     ]
   }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
@@ -747,7 +747,7 @@ public class StorageBlobClient {
          * @param storageBlobClientId the unique id for the {@link StorageBlobClient} this builder builds.
          * @param serviceClientBuilder The {@link com.azure.android.core.http.ServiceClient.Builder}.
          */
-        private Builder(String storageBlobClientId, ServiceClient.Builder serviceClientBuilder) {
+        public Builder(String storageBlobClientId, ServiceClient.Builder serviceClientBuilder) {
             this(storageBlobClientId, serviceClientBuilder, new Constraints.Builder());
             this.transferConstraintsBuilder
                 .setRequiredNetworkType(NetworkType.CONNECTED);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
@@ -12,7 +12,6 @@ import androidx.annotation.RequiresApi;
 import androidx.lifecycle.LiveData;
 import androidx.work.Constraints;
 import androidx.work.NetworkType;
-import android.net.Uri;
 
 import com.azure.android.core.http.Callback;
 import com.azure.android.core.http.ServiceCall;
@@ -192,7 +191,7 @@ public class StorageBlobClient {
      * Pause a transfer identified by the given transfer ID. The pause operation is a best-effort, and a transfer
      * that is already executing may continue to transfer.
      * <p>
-     * Upon successful scheduling of the pause, any observer observing on {@link LiveData<TransferInfo>} for this
+     * Upon successful scheduling of the pause, any observer observing on {@link LiveData} for this
      * transfer receives a {@link TransferInfo} event with state {@link TransferInfo.State#USER_PAUSED}.
      *
      * @param context    The application context.
@@ -219,9 +218,10 @@ public class StorageBlobClient {
      * Cancel a transfer identified by the given transfer ID. The cancel operation is a best-effort, and a transfer
      * that is already executing may continue to transfer.
      * <p>
-     * Upon successful scheduling of the cancellation, any observer observing on {@link LiveData<TransferInfo>} for
+     * Upon successful scheduling of the cancellation, any observer observing on {@link LiveData} for
      * this transfer receives a {@link TransferInfo} event with state {@link TransferInfo.State#CANCELLED}.
      *
+     * @param context    The application context.
      * @param transferId The transfer ID identifies the transfer to cancel.
      */
     public void cancel(Context context, long transferId) {
@@ -441,8 +441,8 @@ public class StorageBlobClient {
      *
      * <p>
      * This method will execute a raw HTTP GET in order to download a single blob to the destination.
-     * It is **STRONGLY** recommended that you use the {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, File)}
-     * or {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, Uri)} method instead - that method will
+     * It is **STRONGLY** recommended that you use the {@link StorageBlobClient#download(Context, String, String, File)}
+     * or {@link StorageBlobClient#download(Context, String, String, Uri)} method instead - that method will
      * manage the transfer in the face of changing network conditions, and is able to transfer multiple
      * blocks in parallel.
      *`
@@ -461,8 +461,8 @@ public class StorageBlobClient {
      *
      * <p>
      * This method will execute a raw HTTP GET in order to download a single blob to the destination.
-     * It is **STRONGLY** recommended that you use the {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, File)}
-     * or {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, Uri)} method instead - that method will
+     * It is **STRONGLY** recommended that you use the {@link StorageBlobClient#download(Context, String, String, File)}
+     * or {@link StorageBlobClient#download(Context, String, String, Uri)} method instead - that method will
      * manage the transfer in the face of changing network conditions, and is able to transfer multiple
      * blocks in parallel.
      *
@@ -484,8 +484,8 @@ public class StorageBlobClient {
      *
      * <p>
      * This method will execute a raw HTTP GET in order to download a single blob to the destination.
-     * It is **STRONGLY** recommended that you use the {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, File)}
-     * or {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, Uri)} method instead - that method will
+     * It is **STRONGLY** recommended that you use the {@link StorageBlobClient#download(Context, String, String, File)}
+     * or {@link StorageBlobClient#download(Context, String, String, Uri)} method instead - that method will
      * manage the transfer in the face of changing network conditions, and is able to transfer multiple
      * blocks in parallel.
      *
@@ -546,8 +546,8 @@ public class StorageBlobClient {
      *
      * <p>
      * This method will execute a raw HTTP GET in order to download a single blob to the destination.
-     * It is **STRONGLY** recommended that you use the {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, File)}
-     * or {@link com.azure.android.storage.blob.transfer.TransferClient#download(String, String, String, Uri)} method instead - that method will
+     * It is **STRONGLY** recommended that you use the {@link StorageBlobClient#download(Context, String, String, File)}
+     * or {@link StorageBlobClient#download(Context, String, String, Uri)} method instead - that method will
      * manage the transfer in the face of changing network conditions, and is able to transfer multiple
      * blocks in parallel.
      *
@@ -931,7 +931,7 @@ public class StorageBlobClient {
          * The builder produced {@link ServiceClient} is used by the {@link StorageBlobClient} to make Rest API calls.
          * Multiple {@link StorageBlobClient} instances can share the same {@link ServiceClient} instance, for e.g.
          * when a new {@link StorageBlobClient} is created from an existing {@link StorageBlobClient} through
-         * {@link StorageBlobClient#newBuilder()} then both shares the same {@link ServiceClient}.
+         * {@link StorageBlobClient#newBuilder(String)} ()} then both shares the same {@link ServiceClient}.
          * The {@link ServiceClient} composes HttpClient, HTTP settings (such as connection timeout, interceptors)
          * and Retrofit for Rest calls.
          *

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
@@ -67,13 +67,14 @@ public class StorageBlobClient {
     /**
      * Creates a new {@link Builder} with initial configuration copied from this {@link StorageBlobClient}.
      *
-     * @param storageBlobClientId the unique id for the new {@link StorageBlobClient}.
-     *     This identifier is used to associate the {@link StorageBlobClient} with the upload, download transfers
-     *     it initiates. When a transfer is reloaded from disk (e.g. after an application crash), it can only be
-     *     resumed once a client with the same storageBlobClientId has been initialized.
+     * @param storageBlobClientId The unique ID for the new {@link StorageBlobClient}. This identifier is used to
+     *                            associate the {@link StorageBlobClient} with the upload and download transfers it
+     *                            initiates. When a transfer is reloaded from disk (e.g. after an application crash),
+     *                            it can only be resumed once a client with the same storageBlobClientId has been
+     *                            initialized.
      * @return A new {@link Builder}.
      */
-    public StorageBlobClient.Builder newBuilder(String  storageBlobClientId) {
+    public StorageBlobClient.Builder newBuilder(String storageBlobClientId) {
         return new Builder(storageBlobClientId, this);
     }
 
@@ -89,11 +90,11 @@ public class StorageBlobClient {
     /**
      * Upload the content of a file.
      *
-     * @param context the application context
-     * @param containerName the container to upload the file to
-     * @param blobName the name of the target blob holding uploaded file
-     * @param file the local file to upload
-     * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
+     * @param context       The application context.
+     * @param containerName The container to upload the file to.
+     * @param blobName      The name of the target blob holding the uploaded file.
+     * @param file          The local file to upload.
+     * @return A LiveData that streams {@link TransferInfo} describing the current state of the transfer.
      */
     public LiveData<TransferInfo> upload(Context context,
                                          String containerName,
@@ -110,15 +111,15 @@ public class StorageBlobClient {
     }
 
     /**
-     * Upload content identified by a given Uri.
+     * Upload content identified by a given URI.
      *
-     * @param context the application context
-     * @param containerName the container to upload the file to
-     * @param blobName the name of the target blob holding uploaded file
-     * @param contentUri URI to the Content to upload, the contentUri is resolved using
-     *   {@link android.content.ContentResolver#openAssetFileDescriptor(Uri, String)}
-     *   with mode as "r". The supported URI schemes are: 'content://', 'file://' and 'android.resource://'
-     * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
+     * @param context       The application context.
+     * @param containerName The container to upload the file to.
+     * @param blobName      The name of the target blob holding the uploaded file.
+     * @param contentUri    The URI to the Content to upload, the contentUri is resolved using
+     *                      {@link android.content.ContentResolver#openAssetFileDescriptor(Uri, String)} with mode as
+     *                      "r". The supported URI schemes are: 'content://', 'file://' and 'android.resource://'.
+     * @return A LiveData that streams {@link TransferInfo} describing the current state of the transfer.
      */
     public LiveData<TransferInfo> upload(Context context,
                                          String containerName,
@@ -138,11 +139,11 @@ public class StorageBlobClient {
     /**
      * Download a blob.
      *
-     * @param context the application context
+     * @param context       The application context.
      * @param containerName The container to download the blob from.
-     * @param blobName The name of the target blob to download.
-     * @param file The local file to download to.
-     * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
+     * @param blobName      The name of the target blob to download.
+     * @param file          The local file to download to.
+     * @return A LiveData that streams {@link TransferInfo} describing the current state of the download.
      */
     public LiveData<TransferInfo> download(Context context,
                                            String containerName,
@@ -162,10 +163,10 @@ public class StorageBlobClient {
     /**
      * Download a blob.
      *
-     * @param context the application context
+     * @param context       The application context.
      * @param containerName The container to download the blob from.
-     * @param blobName The name of the target blob to download.
-     * @param contentUri The URI to the local content where the downloaded blob will be stored.
+     * @param blobName      The name of the target blob to download.
+     * @param contentUri    The URI to the local content where the downloaded blob will be stored.
      * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
      */
     public LiveData<TransferInfo> download(Context context,
@@ -184,16 +185,14 @@ public class StorageBlobClient {
     }
 
     /**
-     * Pause a transfer identified by the given transfer id. The pause operation
-     * is a best-effort, and a transfer that is already executing may continue to
-     * transfer.
+     * Pause a transfer identified by the given transfer ID. The pause operation is a best-effort, and a transfer
+     * that is already executing may continue to transfer.
+     * <p>
+     * Upon successful scheduling of the pause, any observer observing on {@link LiveData<TransferInfo>} for this
+     * transfer receives a {@link TransferInfo} event with state {@link TransferInfo.State#USER_PAUSED}.
      *
-     * Upon successful scheduling of the pause, any observer observing on
-     * {@link LiveData<TransferInfo>} for this transfer receives a {@link TransferInfo}
-     * event with state {@link TransferInfo.State#USER_PAUSED}.
-     *
-     * @param context the application context
-     * @param transferId the transfer id identifies the transfer to pause.
+     * @param context    The application context.
+     * @param transferId The transfer ID identifies the transfer to pause.
      */
     public void pause(Context context, long transferId) {
         TransferClient.getInstance(context)
@@ -203,9 +202,9 @@ public class StorageBlobClient {
     /**
      * Resume a paused transfer.
      *
-     * @param context the application context
-     * @param transferId the transfer id identifies the transfer to resume.
-     * @return LiveData that streams {@link TransferInfo} describing the current state of the transfer
+     * @param context    The application context
+     * @param transferId The transfer ID identifies the transfer to resume.
+     * @return A LiveData that streams {@link TransferInfo} describing the current state of the transfer.
      */
     public LiveData<TransferInfo> resume(Context context, long transferId) {
         return TransferClient.getInstance(context)
@@ -215,7 +214,7 @@ public class StorageBlobClient {
     /**
      * Cancel a transfer identified by the given transfer ID. The cancel operation is a best-effort, and a transfer
      * that is already executing may continue to transfer.
-     *
+     * <p>
      * Upon successful scheduling of the cancellation, any observer observing on {@link LiveData<TransferInfo>} for
      * this transfer receives a {@link TransferInfo} event with state {@link TransferInfo.State#CANCELLED}.
      *
@@ -728,10 +727,11 @@ public class StorageBlobClient {
         /**
          * Creates a {@link Builder}.
          *
-         * @param storageBlobClientId the unique id for the {@link StorageBlobClient} this builder builds.
-         *     This identifier is used to associate this {@link StorageBlobClient} with the upload, download transfers
-         *     it initiates. When a transfer is reloaded from disk (e.g. after an application crash), it can only be
-         *     resumed once a client with the same storageBlobClientId has been initialized.
+         * @param storageBlobClientId The unique ID for the {@link StorageBlobClient} this builder builds. This
+         *                            identifier is used to associate this {@link StorageBlobClient} with the upload and
+         *                            download transfers it initiates. When a transfer is reloaded from disk (e.g.
+         *                            after an application crash), it can only be resumed once a client with the same
+         *                            storageBlobClientId has been initialized.
          */
         public Builder(String storageBlobClientId) {
             this(storageBlobClientId, new ServiceClient.Builder());
@@ -744,7 +744,7 @@ public class StorageBlobClient {
          * Creates a {@link Builder} that uses the provided {@link com.azure.android.core.http.ServiceClient.Builder}
          * to build a {@link ServiceClient} for the {@link StorageBlobClient}.
          *
-         * @param storageBlobClientId the unique id for the {@link StorageBlobClient} this builder builds.
+         * @param storageBlobClientId  The unique ID for the {@link StorageBlobClient} this builder builds.
          * @param serviceClientBuilder The {@link com.azure.android.core.http.ServiceClient.Builder}.
          */
         public Builder(String storageBlobClientId, ServiceClient.Builder serviceClientBuilder) {
@@ -773,7 +773,7 @@ public class StorageBlobClient {
          * Sets the base URL for the {@link StorageBlobClient}.
          *
          * @param blobServiceUrl The blob service base URL.
-         * @return Builder with provided blob service url set
+         * @return An updated {@link Builder} with the provided blob service URL set.
          */
         public Builder setBlobServiceUrl(String blobServiceUrl) {
             Objects.requireNonNull(blobServiceUrl, "blobServiceUrl cannot be null.");
@@ -785,7 +785,7 @@ public class StorageBlobClient {
          * Sets an interceptor used to authenticate the blob service request.
          *
          * @param credentialInterceptor The credential interceptor.
-         * @return Builder with provided credentials interceptor set
+         * @return An updated {@link Builder} with the provided credentials interceptor set.
          */
         public Builder setCredentialInterceptor(Interceptor credentialInterceptor) {
             this.serviceClientBuilder.setCredentialsInterceptor(credentialInterceptor);
@@ -793,11 +793,10 @@ public class StorageBlobClient {
         }
 
         /**
-         * Sets whether device should be charging for running the transfers.
-         * The default value is {@code false}.
+         * Sets whether device should be charging for running the transfers. The default value is {@code false}.
          *
-         * @param requiresCharging {@code true} if device must be charging for the transfer to run
-         * @return Builder with provided charging requirement set
+         * @param requiresCharging {@code true} if the device must be charging for the transfer to run.
+         * @return An updated {@link Builder} with the provided charging requirement set.
          */
         public Builder setRequiresCharging(boolean requiresCharging) {
             this.transferConstraintsBuilder.setRequiresCharging(requiresCharging);
@@ -805,11 +804,10 @@ public class StorageBlobClient {
         }
 
         /**
-         * Sets whether device should be idle for running the transfers.
-         * The default value is {@code false}.
+         * Sets whether device should be idle for running the transfers. The default value is {@code false}.
          *
-         * @param requiresDeviceIdle {@code true} if device must be idle for transfers to run
-         * @return An updated {@link Builder} with these settings applied.
+         * @param requiresDeviceIdle {@code true} if the device must be idle for transfers to run.
+         * @return An updated {@link Builder} with the provided setting set.
          */
         @RequiresApi(23)
         public Builder setRequiresDeviceIdle(boolean requiresDeviceIdle) {
@@ -820,13 +818,12 @@ public class StorageBlobClient {
         }
 
         /**
-         * Sets the particular {@link NetworkType} the device should be in for running
-         * the transfers.
-         *
+         * Sets the particular {@link NetworkType} the device should be in for running the transfers.
+         * <p>
          * The default network type that {@link TransferClient} uses is {@link NetworkType#CONNECTED}.
          *
-         * @param networkType The type of network required for transfers to run
-         * @return Builder with provided network type set
+         * @param networkType The type of network required for transfers to run.
+         * @return An updated {@link Builder} with the provided network type set.
          */
         public Builder setRequiredNetworkType(@NonNull NetworkType networkType) {
             Objects.requireNonNull(networkType, "'networkType' cannot be null.");
@@ -839,12 +836,12 @@ public class StorageBlobClient {
         }
 
         /**
-         * Sets whether device battery should be at an acceptable level for running the transfers.
-         * The default value is {@code false}.
+         * Sets whether device battery should be at an acceptable level for running the transfers. The default value
+         * is {@code false}.
          *
-         * @param requiresBatteryNotLow {@code true} if the battery should be at an acceptable level
-         *                              for the transfers to run
-         * @return Builder with provided battery requirement set
+         * @param requiresBatteryNotLow {@code true} if the battery should be at an acceptable level for the
+         *                                          transfers to run.
+         * @return An updated {@link Builder} with the provided battery requirement set.
          */
         public Builder setRequiresBatteryNotLow(boolean requiresBatteryNotLow) {
             this.transferConstraintsBuilder.setRequiresBatteryNotLow(requiresBatteryNotLow);
@@ -856,8 +853,8 @@ public class StorageBlobClient {
          * the transfers. The default value is {@code false}.
          *
          * @param requiresStorageNotLow {@code true} if the available storage should not be below a
-         *                              a critical threshold for the transfer to run
-         * @return Builder with provided storage requirement set
+         *                              a critical threshold for the transfer to run.
+         * @return An updated {@link Builder} with the provided storage requirement set.
          */
         public Builder setRequiresStorageNotLow(boolean requiresStorageNotLow) {
             this.transferConstraintsBuilder.setRequiresStorageNotLow(requiresStorageNotLow);

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
@@ -3,11 +3,14 @@
 
 package com.azure.android.storage.blob.transfer;
 
+import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
+import androidx.room.Embedded;
 import androidx.room.Entity;
 import androidx.room.Ignore;
 import androidx.room.PrimaryKey;
 import androidx.room.TypeConverters;
+import androidx.work.Constraints;
 
 import java.util.Objects;
 
@@ -82,7 +85,12 @@ final class BlobDownloadEntity {
     @ColumnInfo(name = "transfer_interrupt_state")
     @TypeConverters(ColumnConverter.class)
     public TransferInterruptState interruptState;
-
+    /**
+     * The constraints to be satisfied to run the download operation.
+     */
+    @Embedded
+    @NonNull
+    public ConstraintsColumn constraintsColumn = ConstraintsColumn.NONE;
     /**
      * Holds the exception indicating the reason for download failure.
      *
@@ -105,17 +113,20 @@ final class BlobDownloadEntity {
      * @param blobName The blob name.
      * @param blobSize The blob size.
      * @param content Describes the content where the downloaded blob will be stored.
+     * @param constraints the constraints to be satisfied to run the download operation.
      */
     @Ignore
     BlobDownloadEntity(String storageBlobClientId,
                        String containerName,
                        String blobName,
                        long blobSize,
-                       WritableContent content) {
+                       WritableContent content,
+                       Constraints constraints) {
         Objects.requireNonNull(storageBlobClientId);
         Objects.requireNonNull(containerName);
         Objects.requireNonNull(blobName);
         Objects.requireNonNull(content);
+        Objects.requireNonNull(constraints);
 
         this.storageBlobClientId = storageBlobClientId;
         this.containerName = containerName;
@@ -125,6 +136,7 @@ final class BlobDownloadEntity {
         this.useContentResolver = content.isUsingContentResolver();
         state = BlobTransferState.WAIT_TO_BEGIN;
         interruptState = TransferInterruptState.NONE;
+        constraintsColumn = ConstraintsColumn.fromConstraints(constraints);
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobDownloadEntity.java
@@ -113,7 +113,7 @@ final class BlobDownloadEntity {
      * @param blobName The blob name.
      * @param blobSize The blob size.
      * @param content Describes the content where the downloaded blob will be stored.
-     * @param constraints the constraints to be satisfied to run the download operation.
+     * @param constraints The constraints to be satisfied to run the download operation.
      */
     @Ignore
     BlobDownloadEntity(String storageBlobClientId,

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
@@ -105,7 +105,7 @@ final class BlobUploadEntity {
      * @param containerName the container name
      * @param blobName the blob name
      * @param content describes the content to be read while uploading
-     * @param constraints the constraints to be satisfied to run the upload operation
+     * @param constraints The constraints to be satisfied to run the upload operation.
      */
     @Ignore
     BlobUploadEntity(String storageBlobClientId,

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/BlobUploadEntity.java
@@ -3,11 +3,14 @@
 
 package com.azure.android.storage.blob.transfer;
 
+import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
+import androidx.room.Embedded;
 import androidx.room.Entity;
 import androidx.room.Ignore;
 import androidx.room.PrimaryKey;
 import androidx.room.TypeConverters;
+import androidx.work.Constraints;
 
 import java.util.Objects;
 
@@ -75,6 +78,12 @@ final class BlobUploadEntity {
     @TypeConverters(ColumnConverter.class)
     public TransferInterruptState interruptState;
     /**
+     * The constraints to be satisfied to run the upload operation.
+     */
+    @Embedded
+    @NonNull
+    public ConstraintsColumn constraintsColumn = ConstraintsColumn.NONE;
+    /**
      * holds the exception indicating the reason for commit (the last
      * stage of upload) failure.
      *
@@ -96,16 +105,19 @@ final class BlobUploadEntity {
      * @param containerName the container name
      * @param blobName the blob name
      * @param content describes the content to be read while uploading
+     * @param constraints the constraints to be satisfied to run the upload operation
      */
     @Ignore
     BlobUploadEntity(String storageBlobClientId,
                      String containerName,
                      String blobName,
-                     ReadableContent content) throws Throwable {
+                     ReadableContent content,
+                     Constraints constraints) throws Throwable {
         Objects.requireNonNull(storageBlobClientId);
         Objects.requireNonNull(containerName);
         Objects.requireNonNull(blobName);
         Objects.requireNonNull(content);
+        Objects.requireNonNull(constraints);
 
         this.contentUri = content.getUri().toString();
         this.contentSize = content.getLength();
@@ -116,6 +128,7 @@ final class BlobUploadEntity {
         this.blobName = blobName;
         this.state = BlobTransferState.WAIT_TO_BEGIN;
         this.interruptState = TransferInterruptState.NONE;
+        this.constraintsColumn = ConstraintsColumn.fromConstraints(constraints);
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ColumnConverter.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ColumnConverter.java
@@ -40,4 +40,14 @@ final class ColumnConverter {
     public TransferInterruptState toTransferInterruptState(int ordinal) {
         return TransferInterruptState.values()[ordinal];
     }
+
+    @TypeConverter
+    public int fromNetworkType(androidx.work.NetworkType networkType) {
+        return networkType.ordinal();
+    }
+
+    @TypeConverter
+    public androidx.work.NetworkType toNetworkType(int ordinal) {
+        return androidx.work.NetworkType.values()[ordinal];
+    }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ConstraintsColumn.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/ConstraintsColumn.java
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import android.os.Build;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Ignore;
+import androidx.work.NetworkType;
+
+import java.util.Objects;
+
+import static androidx.work.NetworkType.NOT_REQUIRED;
+
+/**
+ * Type representing constraints embedded in the {@link BlobUploadEntity} and {@link BlobDownloadEntity}.
+ */
+final class ConstraintsColumn {
+    /**
+     * Represents a Constraints column with no requirements.
+     */
+    @Ignore
+    static final ConstraintsColumn NONE = new ConstraintsColumn(androidx.work.Constraints.NONE);
+
+    @ColumnInfo(name = "required_network_type")
+    public NetworkType requiredNetworkType = NOT_REQUIRED;
+
+    @ColumnInfo(name = "requires_charging")
+    public boolean requiresCharging;
+
+    @ColumnInfo(name = "requires_device_idle")
+    public boolean requiresDeviceIdle;
+
+    @ColumnInfo(name = "requires_battery_not_low")
+    public boolean requiresBatteryNotLow;
+
+    @ColumnInfo(name = "requires_storage_not_low")
+    public boolean requiresStorageNotLow;
+
+    /**
+     * Creates ConstraintsEntity, this constructor is used by Room library when re-hydrating metadata from local
+     * store.
+     */
+    public ConstraintsColumn() {}
+
+    /**
+     * Create a new ConstraintsColumn to persist in local store.
+     *
+     * @param constraints the androidx work constraints
+     */
+    private ConstraintsColumn(androidx.work.Constraints constraints) {
+        Objects.requireNonNull(constraints);
+
+        this.requiredNetworkType = constraints.getRequiredNetworkType();
+        this.requiresCharging = constraints.requiresCharging();
+        if (Build.VERSION.SDK_INT >= 23) {
+            this.requiresDeviceIdle = constraints.requiresDeviceIdle();
+        }
+        this.requiresBatteryNotLow = constraints.requiresBatteryNotLow();
+        this.requiresStorageNotLow = constraints.requiresStorageNotLow();
+    }
+
+    /**
+     * Create a {@link ConstraintsColumn} from the given constraints.
+     *
+     * @param constraints the androidx work constraints
+     * @return the {@link ConstraintsColumn}
+     */
+    static ConstraintsColumn fromConstraints(androidx.work.Constraints constraints) {
+        return new ConstraintsColumn(constraints);
+    }
+
+    /**
+     * Creates {@link androidx.work.Constraints} from this {@link ConstraintsColumn}.
+     *
+     * @return the {@link androidx.work.Constraints}
+     */
+    androidx.work.Constraints toConstraints() {
+        androidx.work.Constraints.Builder builder = new androidx.work.Constraints.Builder();
+        builder.setRequiredNetworkType(this.requiredNetworkType);
+        builder.setRequiresCharging(this.requiresCharging);
+        if (Build.VERSION.SDK_INT >= 23) {
+            builder.setRequiresDeviceIdle(this.requiresDeviceIdle);
+        }
+        builder.setRequiresBatteryNotLow(this.requiresBatteryNotLow);
+        builder.setRequiresStorageNotLow(this.requiresStorageNotLow);
+        return builder.build();
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadHandler.java
@@ -149,7 +149,7 @@ final class DownloadHandler extends Handler {
      * Handler. This stage also starts a download operation.
      */
     private void handleInit() {
-        this.db = TransferDatabase.get(appContext);
+        this.db = TransferDatabase.getInstance(appContext);
         this.blob = db.downloadDao().getBlob(downloadId);
 
         if (this.blob.interruptState == TransferInterruptState.PURGE) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadRequest.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadRequest.java
@@ -26,17 +26,17 @@ public final class DownloadRequest {
     /**
      * Create DownloadRequest.
      *
-     * @param storageClientId identifies the the blob storage client for the download
-     * @param containerName the name of the container holding the blob to download
-     * @param blobName  the name of the blob to download
-     * @param writableContent the object describing the content in the device to store the downloaded blob
-     * @param constraints the constraints to be satisfied to execute the download
+     * @param storageClientId Identifies the {@link com.azure.android.storage.blob.StorageBlobClient} for the download.
+     * @param containerName   The name of the container holding the blob to download.
+     * @param blobName        The name of the blob to download.
+     * @param writableContent The object describing the content in the device to store the downloaded blob.
+     * @param constraints     The constraints to be satisfied to execute the download.
      */
     private DownloadRequest(String storageClientId,
-                    String containerName,
-                    String blobName,
-                    WritableContent writableContent,
-                    Constraints constraints) {
+                            String containerName,
+                            String blobName,
+                            WritableContent writableContent,
+                            Constraints constraints) {
         this.storageClientId = storageClientId;
         this.containerName = containerName;
         this.blobName = blobName;
@@ -47,7 +47,7 @@ public final class DownloadRequest {
     /**
      * Get the unique identifier of the blob storage client to be used for the download.
      *
-     * @return the unique identifier of the blob storage client
+     * @return The unique identifier of the {@link com.azure.android.storage.blob.StorageBlobClient}.
      */
     String getStorageClientId() {
         return this.storageClientId;
@@ -56,7 +56,7 @@ public final class DownloadRequest {
     /**
      * Get the name of the container holding the blob to download.
      *
-     * @return the container name
+     * @return The container name.
      */
     String getContainerName() {
         return this.containerName;
@@ -65,7 +65,7 @@ public final class DownloadRequest {
     /**
      * Get the name of the blob to download.
      *
-     * @return the blob name
+     * @return The blob name.
      */
     String getBlobName() {
         return this.blobName;
@@ -74,7 +74,7 @@ public final class DownloadRequest {
     /**
      * Get the object describing the content in the device to store the downloaded blob.
      *
-     * @return the content description
+     * @return The content description.
      */
     WritableContent getWritableContent() {
         return this.writableContent;
@@ -83,7 +83,7 @@ public final class DownloadRequest {
     /**
      * Get the constraints to be satisfied to execute the download.
      *
-     * @return the constraints
+     * @return The constraints.
      */
     Constraints getConstraints() {
         return this.constraints;
@@ -108,8 +108,8 @@ public final class DownloadRequest {
         /**
          * Set the unique identifier of the blob storage client to be used for the download.
          *
-         * @param storageClientId the blob storage client id
-         * @return Builder with provided blob storage client id set
+         * @param storageClientId The blob storage client ID.
+         * @return Builder with provided blob storage client ID set.
          */
         public Builder storageClientId(String storageClientId) {
             this.storageClientId = storageClientId;
@@ -119,8 +119,8 @@ public final class DownloadRequest {
         /**
          * Set the name of the container holding the blob to download.
          *
-         * @param containerName the container name
-         * @return Builder with provided container name set
+         * @param containerName The container name.
+         * @return Builder with the provided container name set.
          */
         public Builder containerName(String containerName) {
             this.containerName = containerName;
@@ -130,8 +130,8 @@ public final class DownloadRequest {
         /**
          * Set the name of the blob to download.
          *
-         * @param blobName the blob name
-         * @return Builder with provided blob name set
+         * @param blobName The blob name.
+         * @return Builder with the provided blob name set.
          */
         public Builder blobName(String blobName) {
             this.blobName = blobName;
@@ -141,8 +141,8 @@ public final class DownloadRequest {
         /**
          * Set the local file to download to.
          *
-         * @param file the file
-         * @return Builder with provided file set
+         * @param file The file.
+         * @return Builder with the provided file set.
          */
         public Builder file(File file) {
             Objects.requireNonNull(file, "'file' cannot be null.");
@@ -156,9 +156,9 @@ public final class DownloadRequest {
         /**
          * Set the content in the device where the downloaded blob will be stored.
          *
-         * @param context the application context
-         * @param uri The URI to the local content where the downloaded blob will be stored
-         * @return Builder with provided content description set
+         * @param context The application context.
+         * @param uri     The URI to the local content where the downloaded blob will be stored.
+         * @return Builder with the provided content description set.
          */
         public Builder contentUri(Context context, Uri uri) {
             Objects.requireNonNull(context, "'context' cannot be null.");
@@ -173,8 +173,8 @@ public final class DownloadRequest {
         /**
          * Set the constraints to be satisfied to execute the download.
          *
-         * @param constraints the constraints
-         * @return Builder with provided constraints set
+         * @param constraints The constraints.
+         * @return Builder with the provided constraints set.
          */
         public Builder constraints(Constraints constraints) {
             this.constraints = constraints;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadRequest.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/DownloadRequest.java
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.work.Constraints;
+
+import com.azure.android.core.util.CoreUtil;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * A type specifying parameters for a download transfer that should be enqueued in {@link TransferClient}.
+ */
+public final class DownloadRequest {
+    private final String storageClientId;
+    private final String containerName;
+    private final String blobName;
+    private final WritableContent writableContent;
+    private final Constraints constraints;
+
+    /**
+     * Create DownloadRequest.
+     *
+     * @param storageClientId identifies the the blob storage client for the download
+     * @param containerName the name of the container holding the blob to download
+     * @param blobName  the name of the blob to download
+     * @param writableContent the object describing the content in the device to store the downloaded blob
+     * @param constraints the constraints to be satisfied to execute the download
+     */
+    private DownloadRequest(String storageClientId,
+                    String containerName,
+                    String blobName,
+                    WritableContent writableContent,
+                    Constraints constraints) {
+        this.storageClientId = storageClientId;
+        this.containerName = containerName;
+        this.blobName = blobName;
+        this.writableContent = writableContent;
+        this.constraints = constraints;
+    }
+
+    /**
+     * Get the unique identifier of the blob storage client to be used for the download.
+     *
+     * @return the unique identifier of the blob storage client
+     */
+    String getStorageClientId() {
+        return this.storageClientId;
+    }
+
+    /**
+     * Get the name of the container holding the blob to download.
+     *
+     * @return the container name
+     */
+    String getContainerName() {
+        return this.containerName;
+    }
+
+    /**
+     * Get the name of the blob to download.
+     *
+     * @return the blob name
+     */
+    String getBlobName() {
+        return this.blobName;
+    }
+
+    /**
+     * Get the object describing the content in the device to store the downloaded blob.
+     *
+     * @return the content description
+     */
+    WritableContent getWritableContent() {
+        return this.writableContent;
+    }
+
+    /**
+     * Get the constraints to be satisfied to execute the download.
+     *
+     * @return the constraints
+     */
+    Constraints getConstraints() {
+        return this.constraints;
+    }
+
+    /**
+     * Builder for {@link DownloadRequest}.
+     */
+    public static final class Builder {
+        private String storageClientId;
+        private String containerName;
+        private String blobName;
+        private WritableContent writableContent;
+        private Constraints constraints;
+
+        /**
+         * Creates a {@link Builder}.
+         */
+        public Builder() {
+        }
+
+        /**
+         * Set the unique identifier of the blob storage client to be used for the download.
+         *
+         * @param storageClientId the blob storage client id
+         * @return Builder with provided blob storage client id set
+         */
+        public Builder storageClientId(String storageClientId) {
+            this.storageClientId = storageClientId;
+            return this;
+        }
+
+        /**
+         * Set the name of the container holding the blob to download.
+         *
+         * @param containerName the container name
+         * @return Builder with provided container name set
+         */
+        public Builder containerName(String containerName) {
+            this.containerName = containerName;
+            return this;
+        }
+
+        /**
+         * Set the name of the blob to download.
+         *
+         * @param blobName the blob name
+         * @return Builder with provided blob name set
+         */
+        public Builder blobName(String blobName) {
+            this.blobName = blobName;
+            return this;
+        }
+
+        /**
+         * Set the local file to download to.
+         *
+         * @param file the file
+         * @return Builder with provided file set
+         */
+        public Builder file(File file) {
+            Objects.requireNonNull(file, "'file' cannot be null.");
+            if (this.writableContent != null && this.writableContent.isUsingContentResolver()) {
+                throw new IllegalArgumentException("Both the contentUri and file cannot be set for the same request.");
+            }
+            this.writableContent = new WritableContent(null, Uri.fromFile(file), false);
+            return this;
+        }
+
+        /**
+         * Set the content in the device where the downloaded blob will be stored.
+         *
+         * @param context the application context
+         * @param uri The URI to the local content where the downloaded blob will be stored
+         * @return Builder with provided content description set
+         */
+        public Builder contentUri(Context context, Uri uri) {
+            Objects.requireNonNull(context, "'context' cannot be null.");
+            Objects.requireNonNull(uri, "'uri' cannot be null.");
+            if (this.writableContent != null && !this.writableContent.isUsingContentResolver()) {
+                throw new IllegalArgumentException("Both the contentUri and file cannot be set for the same request.");
+            }
+            this.writableContent = new WritableContent(context, uri, true);
+            return this;
+        }
+
+        /**
+         * Set the constraints to be satisfied to execute the download.
+         *
+         * @param constraints the constraints
+         * @return Builder with provided constraints set
+         */
+        public Builder constraints(Constraints constraints) {
+            this.constraints = constraints;
+            return this;
+        }
+
+        /**
+         * Builds a {@link DownloadRequest} based on this {@link Builder}'s configuration.
+         *
+         * @return A {@link DownloadRequest}.
+         */
+        public DownloadRequest build() {
+            if (CoreUtil.isNullOrEmpty(this.storageClientId)) {
+                throw new IllegalArgumentException("'storageClientId' is required and cannot be null or empty.");
+            }
+            if (CoreUtil.isNullOrEmpty(this.containerName)) {
+                throw new IllegalArgumentException("'containerName' is required and cannot be null or empty.");
+            }
+            if (CoreUtil.isNullOrEmpty(this.blobName)) {
+                throw new IllegalArgumentException("'blobName' is required and cannot be null or empty.");
+            }
+            Objects.requireNonNull(this.writableContent, "either 'file' or 'contentUri' must be set.");
+            Objects.requireNonNull(this.constraints, "'constraints' cannot be null.");
+            return new DownloadRequest(this.storageClientId,
+                this.containerName,
+                this.blobName,
+                this.writableContent,
+                this.constraints);
+        }
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/StorageBlobClientMap.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/StorageBlobClientMap.java
@@ -3,6 +3,8 @@
 
 package com.azure.android.storage.blob.transfer;
 
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 
 import com.azure.android.storage.blob.StorageBlobClient;
@@ -11,26 +13,67 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Package private.
- *
  * A map containing the {@link StorageBlobClient} to be used for low-level storage
  * service calls.
  */
-final class StorageBlobClientMap {
+public final class StorageBlobClientMap {
     /**
      * Map with key as user defined unique identifier and value as associated
      * blob storage client.
      */
     private Map<String, StorageBlobClient> map = new ConcurrentHashMap<>();
+    // The singleton instance of StorageBlobClientMap.
+    private static StorageBlobClientMap INSTANCE = null;
+    // An object to synchronize the creation of the singleton StorageBlobClientMap.
+    private static final Object INIT_LOCK = new Object();
+    // An object to synchronize the operation of adding an entry to the map.
+    private static final Object ADD_LOCK = new Object();
+    /**
+     * Retrieves the singleton instance of {@link StorageBlobClientMap}.
+     *
+     * @return The singleton instance of {@link StorageBlobClientMap}.
+     */
+    public static @NonNull StorageBlobClientMap getInstance() {
+        synchronized (INIT_LOCK) {
+            if (INSTANCE == null) {
+                INSTANCE = new StorageBlobClientMap();
+            }
+            return INSTANCE;
+        }
+    }
+
+    private StorageBlobClientMap() {
+    }
 
     /**
-     * Copies all entries from the given map to this map.
+     * Add a {@link StorageBlobClient} to this map.
      *
-     * @param storageBlobClientMap the blob storage client mapping to be stored in this map
+     * @param storageBlobClientId the unique id of the {@link StorageBlobClient}
+     * @param storageBlobClient the blob storage client
+     * @throws IllegalArgumentException if a {@link StorageBlobClient} with the same id already exists in the map
      */
-    void putAll(@NonNull Map<String, StorageBlobClient> storageBlobClientMap) {
-        this.map.putAll(storageBlobClientMap);
+    public void add(@NonNull String storageBlobClientId, @NonNull StorageBlobClient storageBlobClient) {
+        if (Build.VERSION.SDK_INT >= 24) {
+            this.map.compute(storageBlobClientId, (id, existingClient) -> {
+                if (existingClient != null) {
+                    throw new IllegalArgumentException(
+                        "A StorageBlobClient with id '" + storageBlobClientId + "' already exists.");
+                } else {
+                    return storageBlobClient;
+                }
+            });
+        } else {
+            synchronized (ADD_LOCK) {
+                if (this.contains(storageBlobClientId)) {
+                    throw new IllegalArgumentException(
+                        "A StorageBlobClient with id '" + storageBlobClientId + "' already exists.");
+                } else {
+                    this.map.put(storageBlobClientId, storageBlobClient);
+                }
+            }
+        }
     }
+
 
     /**
      * Get the {@link StorageBlobClient} for a specified id.
@@ -38,7 +81,7 @@ final class StorageBlobClientMap {
      * @param storageBlobClientId the unique id of the {@link StorageBlobClient} to retrieve
      * @return the blob storage client if exists, null otherwise
      */
-    StorageBlobClient get(String storageBlobClientId) {
+    public StorageBlobClient get(String storageBlobClientId) {
         return this.map.get(storageBlobClientId);
     }
 
@@ -48,7 +91,7 @@ final class StorageBlobClientMap {
      * @param storageBlobClientId the unique id of the blob storage client
      * @return {@code true} if this map contains a blob storage client for the specified id
      */
-    boolean contains(@NonNull String storageBlobClientId) {
+    public boolean contains(@NonNull String storageBlobClientId) {
         return this.map.containsKey(storageBlobClientId);
     }
 
@@ -57,7 +100,7 @@ final class StorageBlobClientMap {
      *
      * @return {@code true} if this map contains no entries
      */
-    boolean isEmpty() {
+    public boolean isEmpty() {
         return this.map.isEmpty();
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/StorageBlobClientMap.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/StorageBlobClientMap.java
@@ -48,9 +48,9 @@ public final class StorageBlobClientMap {
     /**
      * Add a {@link StorageBlobClient} to this map.
      *
-     * @param storageBlobClientId the unique id of the {@link StorageBlobClient}
-     * @param storageBlobClient the blob storage client
-     * @throws IllegalArgumentException if a {@link StorageBlobClient} with the same id already exists in the map
+     * @param storageBlobClientId The unique ID of the {@link StorageBlobClient}.
+     * @param storageBlobClient The blob storage client.
+     * @throws IllegalArgumentException If a {@link StorageBlobClient} with the same ID already exists in the map.
      */
     public void add(@NonNull String storageBlobClientId, @NonNull StorageBlobClient storageBlobClient) {
         if (Build.VERSION.SDK_INT >= 24) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -56,7 +56,7 @@ public final class TransferClient {
      *
      * @param context A {@link Context} for on-demand initialization.
      * @return The singleton instance of {@link TransferClient}.
-     * @throws IllegalStateException If underlying Database or WorkManager is not initialized properly
+     * @throws IllegalStateException If underlying Database or {@link WorkManager} is not initialized properly.
      */
     public static @NonNull TransferClient getInstance(@NonNull Context context) throws IllegalStateException {
         synchronized (INIT_LOCK) {
@@ -91,7 +91,7 @@ public final class TransferClient {
     /**
      * Upload the content described by the given {@link ReadableContent}.
      *
-     * @param uploadRequest describes the upload request
+     * @param uploadRequest Describes the upload request.
      * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
      */
     public LiveData<TransferInfo> upload(UploadRequest uploadRequest) {
@@ -151,7 +151,7 @@ public final class TransferClient {
     /**
      * Download a blob.
      *
-     * @param downloadRequest describes the download request
+     * @param downloadRequest Describes the download request.
      * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
      */
     public LiveData<TransferInfo> download(DownloadRequest downloadRequest) {

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -5,13 +5,10 @@ package com.azure.android.storage.blob.transfer;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.net.Uri;
-import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Transformations;
@@ -19,106 +16,86 @@ import androidx.work.Constraints;
 import androidx.work.Data;
 import androidx.work.ExistingWorkPolicy;
 import androidx.work.ListenableWorker;
-import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import androidx.work.impl.WorkManagerImpl;
 
 import com.azure.android.storage.blob.StorageBlobClient;
 
-import java.io.File;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 /**
  * A type that exposes blob transfer APIs.
  */
-public class TransferClient {
-    // the static shared map of StorageBlobClient instances for transfers, with package
-    // scoped access. StorageBlobClient instances are added from TransferClient.Builder
-    // and used by Upload|Download handlers.
-    static final StorageBlobClientMap STORAGE_BLOB_CLIENTS = new StorageBlobClientMap();
+public final class TransferClient {
     private static final String TAG = TransferClient.class.getSimpleName();
-    // the application context.
-    private final Context context;
-    // the constraints to meet to run the transfers.
-    private final Constraints constraints;
     // the executor for internal book keeping.
     private SerialExecutor serialTaskExecutor;
     // reference to the database holding transfer entities.
     private final TransferDatabase db;
+    // reference to the androidx work manager.
+    private final WorkManager workManager;
     // track the active (not collected by GC) Transfers.
-    private final static TransferIdInfoLiveDataCache TRANSFER_ID_INFO_CACHE = new TransferIdInfoLiveDataCache();
+    private final TransferIdInfoLiveDataCache transferIdInfoCache = new TransferIdInfoLiveDataCache();
+    // The singleton TransferClient.
+    private static TransferClient INSTANCE = null;
+    // An object to synchronize the creation of the singleton TransferClient.
+    private static final Object INIT_LOCK = new Object();
+    // the static shared map of StorageBlobClient instances for transfers, with package
+    // scoped access. StorageBlobClient instances are added from TransferClient.Builder
+    // and used by Upload|Download handlers.
+    static final StorageBlobClientMap STORAGE_BLOB_CLIENTS;
 
-    /**
-     * Creates a {@link TransferClient} that uses provided {@link StorageBlobClient}
-     * for transfers.
-     *
-     * @param context the context
-     * @param constraints the constraints to meet to run transfers
-     * @param serialTaskExecutor the executor for all internal book keeping purposes
-     * @param storageBlobClients the blob storage clients for transfers
-     */
-    private TransferClient(Context context,
-                           Constraints constraints,
-                           SerialExecutor serialTaskExecutor,
-                           Map<String, StorageBlobClient> storageBlobClients) {
-        this.context = context;
-        this.constraints = constraints;
-        this.serialTaskExecutor = serialTaskExecutor;
-        this.db = TransferDatabase.get(context);
-        STORAGE_BLOB_CLIENTS.putAll(storageBlobClients);
+    static {
+        STORAGE_BLOB_CLIENTS = StorageBlobClientMap.getInstance();
     }
 
     /**
-     * Upload the content of a file.
+     * Retrieves the singleton instance of {@link TransferClient}.
      *
-     * @param storageBlobClientId the identifier of the blob storage client to use for the upload
-     * @param containerName the container to upload the file to
-     * @param blobName the name of the target blob holding uploaded file
-     * @param file the local file to upload
-     * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
+     * @param context A {@link Context} for on-demand initialization.
+     * @return The singleton instance of {@link TransferClient}.
+     * @throws IllegalStateException If underlying Database or WorkManager is not initialized properly
      */
-    public LiveData<TransferInfo> upload(String storageBlobClientId, String containerName, String blobName, File file) {
-        // UI_Thread
-        return upload(storageBlobClientId, containerName, blobName,
-            new ReadableContent(this.context, Uri.fromFile(file), false));
+    public static @NonNull TransferClient getInstance(@NonNull Context context) throws IllegalStateException {
+        synchronized (INIT_LOCK) {
+            if (INSTANCE == null) {
+                INSTANCE = new TransferClient(context.getApplicationContext());
+            }
+            return INSTANCE;
+        }
     }
 
     /**
-     * Upload content identified by a given Uri.
+     * Create an instance of {@link TransferClient}.
      *
-     * @param storageBlobClientId the identifier of the blob storage client to use for the upload
-     * @param containerName the container to upload the file to
-     * @param blobName the name of the target blob holding uploaded file
-     * @param contentUri URI to the Content to upload, the contentUri is resolved using
-     *   {@link android.content.ContentResolver#openAssetFileDescriptor(Uri, String)}
-     *   with mode as "r". The supported URI schemes are: 'content://', 'file://' and 'android.resource://'
-     * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
+     * @param applicationContext The application {@link Context} for on-demand initialization.
      */
-    public LiveData<TransferInfo> upload(String storageBlobClientId, String containerName, String blobName, Uri contentUri) {
-        // UI_Thread
-        return upload(storageBlobClientId, containerName, blobName,
-            new ReadableContent(this.context, contentUri, true));
+    @SuppressLint("RestrictedApi")
+    private TransferClient(Context applicationContext) {
+        this.db = TransferDatabase.getInstance(applicationContext);
+        this.workManager = WorkManager.getInstance(applicationContext);
+        try {
+            // Reference: https://github.com/Azure/azure-sdk-for-android/pull/203#discussion_r384854043
+            //
+            // Try to re-use the existing taskExecutor shared by WorkManager.
+            WorkManagerImpl wmImpl = (WorkManagerImpl)this.workManager;
+            this.serialTaskExecutor = new SerialExecutor(wmImpl.getConfiguration().getTaskExecutor());
+        } catch (Exception ignored) {
+            // Create our own small ThreadPoolExecutor if we can't.
+            this.serialTaskExecutor = new SerialExecutor(Executors.newFixedThreadPool(2));
+        }
     }
 
     /**
      * Upload the content described by the given {@link ReadableContent}.
      *
-     * @param storageBlobClientId the identifier of the blob storage client to use for the upload
-     * @param containerName the container to upload the file to
-     * @param blobName the name of the target blob holding uploaded file
-     * @param readableContent describes the Content to read and upload
+     * @param uploadRequest describes the upload request
      * @return LiveData that streams {@link TransferInfo} describing current state of the transfer
      */
-    private LiveData<TransferInfo> upload(String storageBlobClientId,
-                                          String containerName,
-                                          String blobName,
-                                          ReadableContent readableContent) {
-        // UI_Thread
+    public LiveData<TransferInfo> upload(UploadRequest uploadRequest) {
+        final ReadableContent readableContent = uploadRequest.getReadableContent();
         final MutableLiveData<TransferOperationResult> transferOpResultLiveData = new MutableLiveData<>();
         try {
             // Take permission immediately in the UI_Thread (granting may require UI interaction).
@@ -129,18 +106,18 @@ public class TransferClient {
             return toCachedTransferInfoLiveData(transferOpResultLiveData, false);
         }
         this.serialTaskExecutor.execute(() -> {
-            // BG_Thread
             try {
-                if (!TransferClient.STORAGE_BLOB_CLIENTS.contains(storageBlobClientId)) {
+                if (!TransferClient.STORAGE_BLOB_CLIENTS.contains(uploadRequest.getStorageClientId())) {
                     transferOpResultLiveData.postValue(TransferOperationResult
                         .unresolvedStorageClientIdError(TransferOperationResult.Operation.UPLOAD_DOWNLOAD,
-                            storageBlobClientId));
+                            uploadRequest.getStorageClientId()));
                     return;
                 }
-                BlobUploadEntity blob = new BlobUploadEntity(storageBlobClientId,
-                    containerName,
-                    blobName,
-                    readableContent);
+                BlobUploadEntity blob = new BlobUploadEntity(uploadRequest.getStorageClientId(),
+                    uploadRequest.getContainerName(),
+                    uploadRequest.getBlobName(),
+                    readableContent,
+                    uploadRequest.getConstraints());
                 List<BlockUploadEntity> blocks
                     = BlockUploadEntity.createBlockEntities(readableContent.getLength(), Constants.DEFAULT_BLOCK_SIZE);
                 long transferId = db.uploadDao().createUploadRecord(blob, blocks);
@@ -151,12 +128,12 @@ public class TransferClient {
                     .build();
                 OneTimeWorkRequest uploadWorkRequest = new OneTimeWorkRequest
                     .Builder(UploadWorker.class)
-                    .setConstraints(constraints)
+                    .setConstraints(uploadRequest.getConstraints())
                     .setInputData(inputData)
                     .build();
 
                 Log.v(TAG, "upload(): enqueuing UploadWorker: " + transferId);
-                WorkManager.getInstance(context)
+                workManager
                     .beginUniqueWork(toTransferUniqueWorkName(transferId),
                         ExistingWorkPolicy.KEEP,
                         uploadWorkRequest)
@@ -168,56 +145,17 @@ public class TransferClient {
                     .postValue(TransferOperationResult.error(TransferOperationResult.Operation.UPLOAD_DOWNLOAD, e));
             }
         });
-        // UI_Thread
         return toCachedTransferInfoLiveData(transferOpResultLiveData, false);
     }
 
     /**
      * Download a blob.
      *
-     * @param storageBlobClientId the identifier of the blob storage client to use for the download
-     * @param containerName The container to download the blob from.
-     * @param blobName The name of the target blob to download.
-     * @param file The local file to download to.
+     * @param downloadRequest describes the download request
      * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
      */
-    public LiveData<TransferInfo> download(String storageBlobClientId, String containerName, String blobName, File file) {
-        return download(storageBlobClientId,
-            containerName,
-            blobName,
-            new WritableContent(this.context, Uri.fromFile(file), false));
-    }
-
-    /**
-     * Download a blob.
-     *
-     * @param storageBlobClientId the identifier of the blob storage client to use for the download
-     * @param containerName The container to download the blob from.
-     * @param blobName The name of the target blob to download.
-     * @param contentUri The URI to the local content where the downloaded blob will be stored.
-     * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
-     */
-    public LiveData<TransferInfo> download(String storageBlobClientId, String containerName, String blobName, Uri contentUri) {
-        return download(storageBlobClientId,
-            containerName,
-            blobName,
-            new WritableContent(this.context, contentUri, true));
-    }
-
-    /**
-     * Download a blob.
-     *
-     * @param storageBlobClientId the identifier of the blob storage client to use for the download
-     * @param containerName The container to download the blob from.
-     * @param blobName The name of the target blob to download.
-     * @param writableContent describes the Content in the device to store the downloaded blob.
-     * @return LiveData that streams {@link TransferInfo} describing the current state of the download.
-     */
-    public LiveData<TransferInfo> download(String storageBlobClientId,
-                                           String containerName,
-                                           String blobName,
-                                           WritableContent writableContent) {
-        // UI_Thread
+    public LiveData<TransferInfo> download(DownloadRequest downloadRequest) {
+        final WritableContent writableContent = downloadRequest.getWritableContent();
         final MutableLiveData<TransferOperationResult> transferOpResultLiveData = new MutableLiveData<>();
         try {
             // Take permission immediately in the UI_Thread (granting may require UI interaction).
@@ -230,20 +168,21 @@ public class TransferClient {
         this.serialTaskExecutor.execute(() -> {
             // BG_Thread
             try {
-                StorageBlobClient blobClient = TransferClient.STORAGE_BLOB_CLIENTS.get(storageBlobClientId);
+                StorageBlobClient blobClient = TransferClient.STORAGE_BLOB_CLIENTS.get(downloadRequest.getStorageClientId());
                 if (blobClient == null) {
                     transferOpResultLiveData.postValue(TransferOperationResult
                         .unresolvedStorageClientIdError(TransferOperationResult.Operation.UPLOAD_DOWNLOAD,
-                            storageBlobClientId));
+                            downloadRequest.getStorageClientId()));
                     return;
                 }
 
-                long blobSize = blobClient.getBlobProperties(containerName, blobName).getContentLength();
-                BlobDownloadEntity blob = new BlobDownloadEntity(storageBlobClientId,
-                    containerName,
-                    blobName,
+                long blobSize = blobClient.getBlobProperties(downloadRequest.getContainerName(), downloadRequest.getBlobName()).getContentLength();
+                BlobDownloadEntity blob = new BlobDownloadEntity(downloadRequest.getStorageClientId(),
+                    downloadRequest.getContainerName(),
+                    downloadRequest.getBlobName(),
                     blobSize,
-                    writableContent);
+                    writableContent,
+                    downloadRequest.getConstraints());
                 List<BlockDownloadEntity> blocks
                     = BlockDownloadEntity.createBlockEntities(blobSize, Constants.DEFAULT_BLOCK_SIZE);
                 long transferId = db.downloadDao().createDownloadRecord(blob, blocks);
@@ -255,13 +194,13 @@ public class TransferClient {
                     .build();
                 OneTimeWorkRequest downloadWorkRequest = new OneTimeWorkRequest
                     .Builder(DownloadWorker.class)
-                    .setConstraints(constraints)
+                    .setConstraints(downloadRequest.getConstraints())
                     .setInputData(inputData)
                     .build();
 
                 Log.v(TAG, "download(): enqueuing DownloadWorker: " + transferId);
 
-                WorkManager.getInstance(context)
+                workManager
                     .beginUniqueWork(toTransferUniqueWorkName(transferId),
                         ExistingWorkPolicy.KEEP,
                         downloadWorkRequest)
@@ -292,7 +231,7 @@ public class TransferClient {
     // P2: Currently no return value, evaluate any possible return value later.
     public void pause(long transferId) {
         // UI_Thread
-        final TransferIdInfoLiveData.TransferFlags transferFlags = TRANSFER_ID_INFO_CACHE.getTransferFlags(transferId);
+        final TransferIdInfoLiveData.TransferFlags transferFlags = transferIdInfoCache.getTransferFlags(transferId);
 
         this.serialTaskExecutor.execute(() -> {
             // BG_Thread
@@ -310,8 +249,7 @@ public class TransferClient {
                         transferFlags.setUserPaused();
                     }
 
-                    WorkManager
-                        .getInstance(context)
+                    workManager
                         .cancelUniqueWork(toTransferUniqueWorkName(transferId));
                 }
             } catch (Exception e) {
@@ -354,7 +292,7 @@ public class TransferClient {
                         .build();
                     workRequest = new OneTimeWorkRequest
                         .Builder(workerClass)
-                        .setConstraints(constraints)
+                        .setConstraints(resumeCheck.constraints)
                         .setInputData(inputData)
                         .build();
 
@@ -364,7 +302,7 @@ public class TransferClient {
                     // With this policy, if the work is already running, then this resume() call is NO-OP,
                     // we return the LiveData to the caller that streams the TransferInfo events of
                     // the already running work.
-                    WorkManager.getInstance(context)
+                    workManager
                         .beginUniqueWork(toTransferUniqueWorkName(transferId),
                             ExistingWorkPolicy.KEEP,
                             workRequest)
@@ -403,8 +341,7 @@ public class TransferClient {
                         db.downloadDao().updateDownloadInterruptState(transferId, TransferInterruptState.USER_CANCELLED);
                     }
 
-                    WorkManager
-                        .getInstance(context)
+                    workManager
                         .cancelUniqueWork(toTransferUniqueWorkName(transferId));
                 }
             } catch (Exception e) {
@@ -440,7 +377,7 @@ public class TransferClient {
         // UI_Thread
         return Transformations.switchMap(transferOpResultLiveData, transferOpResult -> {
             if (transferOpResult.isError()) {
-                final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
+                final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(workManager);
                 final TransferIdInfoLiveData.LiveDataPair pair = result.getLiveDataPair();
                 pair.getTransferOpResultLiveData().setValue(transferOpResult);
                 return pair.getTransferInfoLiveData();
@@ -449,7 +386,7 @@ public class TransferClient {
                     // If the application process already has a cached LiveData pair for the same transfer,
                     // then use it, otherwise create, cache, and use.
                     final TransferIdInfoLiveData.LiveDataPair pair
-                        = TRANSFER_ID_INFO_CACHE.getOrCreate(transferOpResult.getId(), context);
+                        = transferIdInfoCache.getOrCreate(transferOpResult.getId(), workManager);
                     pair.getTransferOpResultLiveData().setValue(transferOpResult);
                     return pair.getTransferInfoLiveData();
                 } else {
@@ -461,7 +398,7 @@ public class TransferClient {
                     //        in the same application process
                     //     2. and the cache entry is not GC-ed.
                     final TransferIdInfoLiveData.LiveDataPair pair
-                        = TRANSFER_ID_INFO_CACHE.create(transferOpResult.getId(), context);
+                        = transferIdInfoCache.create(transferOpResult.getId(), workManager);
                     pair.getTransferOpResultLiveData().setValue(transferOpResult);
                     return pair.getTransferInfoLiveData();
                 }
@@ -482,16 +419,19 @@ public class TransferClient {
         BlobUploadEntity uploadBlob = db.uploadDao().getBlob(transferId);
         BlobTransferState blobTransferState = null;
         String storageBlobClientId = null;
+        Constraints constraints = null;
 
         if (uploadBlob != null) {
             blobTransferState = uploadBlob.state;
             storageBlobClientId = uploadBlob.storageBlobClientId;
+            constraints = uploadBlob.constraintsColumn.toConstraints();
         } else {
             BlobDownloadEntity downloadBlob = db.downloadDao().getBlob(transferId);
 
             if (downloadBlob != null) {
                 blobTransferState = downloadBlob.state;
                 storageBlobClientId = downloadBlob.storageBlobClientId;
+                constraints = downloadBlob.constraintsColumn.toConstraints();
             }
         }
 
@@ -499,26 +439,26 @@ public class TransferClient {
             // No upload or download transfer found.
             transferOpResultLiveData.postValue(TransferOperationResult.notFoundError(transferId));
 
-            return new ResumeCheck(false, false);
+            return new ResumeCheck(false, false, constraints);
         } else {
             if (blobTransferState == BlobTransferState.FAILED) {
                 transferOpResultLiveData.postValue(TransferOperationResult.alreadyInFailedStateError(transferId));
 
-                return new ResumeCheck(false, true);
+                return new ResumeCheck(false, true, constraints);
             } else if (blobTransferState == BlobTransferState.COMPLETED) {
                 transferOpResultLiveData.postValue(TransferOperationResult.alreadyInCompletedStateError(transferId));
 
-                return new ResumeCheck(false, true);
+                return new ResumeCheck(false, true, constraints);
             } else if (!TransferClient.STORAGE_BLOB_CLIENTS.contains(storageBlobClientId)) {
                 transferOpResultLiveData
                     .postValue(TransferOperationResult
                         .unresolvedStorageClientIdError(TransferOperationResult.Operation.UPLOAD_DOWNLOAD,
                             uploadBlob.storageBlobClientId));
 
-                return new ResumeCheck(false, true);
+                return new ResumeCheck(false, true, constraints);
             }
 
-            return new ResumeCheck(true, true);
+            return new ResumeCheck(true, true, constraints);
         }
     }
 
@@ -528,10 +468,13 @@ public class TransferClient {
         final boolean canResume;
         // If the transfer can be resumed then this flag indicates the transfer type (upload|download).
         final boolean isUpload;
+        // The constraints to be satisfied to resume the transfer.
+        final Constraints constraints;
 
-        ResumeCheck(boolean canResume, boolean isUpload) {
+        ResumeCheck(boolean canResume, boolean isUpload, Constraints constraints) {
             this.canResume = canResume;
             this.isUpload = isUpload;
+            this.constraints = constraints;
         }
     }
 
@@ -580,178 +523,6 @@ public class TransferClient {
         private StopCheck(boolean canStop, boolean isUpload) {
             this.canStop = canStop;
             this.isUpload = isUpload;
-        }
-    }
-
-    /**
-     * A builder to configure and build a {@link TransferClient}.
-     */
-    public static final class Builder {
-        // the application context.
-        private Context context;
-        // a map of storage clients to use for transfers.
-        private Map<String, StorageBlobClient> storageBlobClients = new HashMap<>();
-        // indicate whether the device should be charging for running the transfers.
-        private boolean requiresCharging = false;
-        // indicate whether the device should be idle for running the transfers.
-        private boolean requiresDeviceIdle = false;
-        // indicate whether the device battery should be at an acceptable level for running the transfers
-        private boolean requiresBatteryNotLow = false;
-        // indicate whether the device's available storage should be at an acceptable level for running
-        // the transfers
-        private boolean requiresStorageNotLow = false;
-        // the network type required for transfers.
-        private NetworkType networkType = NetworkType.CONNECTED;
-        // the executor for internal book keeping.
-        private SerialExecutor serialTaskExecutor;
-
-        /**
-         * Create a new {@link TransferClient} builder.
-         */
-        public Builder(@NonNull Context context) {
-            this.context = context;
-        }
-
-        /**
-         * Add a {@link StorageBlobClient} to be used for transfers.
-         *
-         * @param storageBlobClientId the unique name or id for the blob storage client.
-         *   This identifier is used to associate the given blob storage client with transfers
-         *   that {@link TransferClient} creates. When a transfer is reloaded from disk (e.g. after an
-         *   application crash), it can only be resumed once a client with the same storageBlobClientId
-         *   has been initialized. If your application only uses a single {@link StorageBlobClient},
-         *   it is recommended to use a value unique to your application (e.g. "MyApplication").
-         *   If your application uses multiple clients with different configurations, use a value unique
-         *   to both your application and the configuration (e.g. "MyApplication.userClient").
-         * @param storageBlobClient the blob storage client
-         * @return Builder with the provided blob storage client set
-         */
-        public Builder addStorageBlobClient(@NonNull String storageBlobClientId,
-                                            @NonNull StorageBlobClient storageBlobClient) {
-            this.storageBlobClients.put(storageBlobClientId, storageBlobClient);
-            return this;
-        }
-
-        /**
-         * Sets whether device should be charging for running the transfers.
-         * The default value is {@code false}.
-         *
-         * @param requiresCharging {@code true} if device must be charging for the transfer to run
-         * @return Builder with provided charging requirement set
-         */
-        public Builder setRequiresCharging(boolean requiresCharging) {
-            this.requiresCharging = requiresCharging;
-            return this;
-        }
-
-        /**
-         * Sets whether device should be idle for running the transfers.
-         * The default value is {@code false}.
-         *
-         * @param requiresDeviceIdle {@code true} if device must be idle for transfers to run
-         * @return Builder with provided idle requirement set
-         */
-        @RequiresApi(23)
-        public Builder setRequiresDeviceIdle(boolean requiresDeviceIdle) {
-            this.requiresDeviceIdle = requiresDeviceIdle;
-            return this;
-        }
-
-        /**
-         * Sets the particular {@link NetworkType} the device should be in for running
-         * the transfers.
-         *
-         * The default network type that {@link TransferClient} uses is {@link NetworkType#CONNECTED}.
-         *
-         * @param networkType The type of network required for transfers to run
-         * @return Builder with provided network type set
-         */
-        public Builder setRequiredNetworkType(@NonNull NetworkType networkType) {
-            this.networkType = networkType;
-            return this;
-        }
-
-        /**
-         * Sets whether device battery should be at an acceptable level for running the transfers.
-         * The default value is {@code false}.
-         *
-         * @param requiresBatteryNotLow {@code true} if the battery should be at an acceptable level
-         *                              for the transfers to run
-         * @return Builder with provided battery requirement set
-         */
-        public Builder setRequiresBatteryNotLow(boolean requiresBatteryNotLow) {
-            this.requiresBatteryNotLow = requiresBatteryNotLow;
-            return this;
-        }
-
-        /**
-         * Sets whether the device's available storage should be at an acceptable level for running
-         * the transfers. The default value is {@code false}.
-         *
-         * @param requiresStorageNotLow {@code true} if the available storage should not be below a
-         *                              a critical threshold for the transfer to run
-         * @return Builder with provided storage requirement set
-         */
-        public Builder setRequiresStorageNotLow(boolean requiresStorageNotLow) {
-            this.requiresStorageNotLow = requiresStorageNotLow;
-            return this;
-        }
-
-        /**
-         * Set the {@link Executor} used by {@link TransferClient} for all its internal
-         * book keeping, which includes creating DB entries for transfer workers, querying DB
-         * for status, submitting transfer request to {@link WorkManager}.
-         *
-         * TransferClient will enqueue a maximum of two commands to the taskExecutor at any time.
-         *
-         * @param executor the executor for internal book keeping
-         * @return Builder with provided taskExecutor set
-         */
-        public Builder setTaskExecutor(@NonNull Executor executor) {
-            this.serialTaskExecutor = new SerialExecutor(executor);
-            return this;
-        }
-
-        /**
-         * @return A {@link TransferClient} configured with settings applied through this builder
-         */
-        // Following annotation is added to suppress library restricted WorkManager
-        // androidx.work.Configuration Object access
-        @SuppressLint("RestrictedApi")
-        public TransferClient build() {
-            if (this.storageBlobClients.isEmpty()) {
-                throw new IllegalArgumentException("At least one storageBlobClient must be set.");
-            }
-            final Constraints.Builder constraintsBuilder = new Constraints.Builder();
-            constraintsBuilder.setRequiresCharging(this.requiresCharging);
-            if (Build.VERSION.SDK_INT >= 23) {
-                constraintsBuilder.setRequiresDeviceIdle(this.requiresDeviceIdle);
-            }
-            if (this.networkType == null) {
-                throw new IllegalArgumentException("networkType must be set.");
-            } else if (this.networkType == NetworkType.NOT_REQUIRED) {
-                throw new IllegalArgumentException(
-                    "The network type NOT_REQUIRED is not a valid transfer configuration.");
-            }
-            constraintsBuilder.setRequiredNetworkType(this.networkType);
-            constraintsBuilder.setRequiresBatteryNotLow(this.requiresBatteryNotLow);
-            constraintsBuilder.setRequiresStorageNotLow(this.requiresStorageNotLow);
-            if (this.serialTaskExecutor == null) {
-                try {
-                    // Reference: https://github.com/Azure/azure-sdk-for-android/pull/203#discussion_r384854043
-                    //
-                    // Try to re-use the existing taskExecutor shared by WorkManager and Room.
-                    WorkManagerImpl wmImpl = (WorkManagerImpl)WorkManager.getInstance(context);
-                    this.serialTaskExecutor = new SerialExecutor(wmImpl.getConfiguration().getTaskExecutor());
-                } catch (Exception ignored) {
-                    // Create our own small ThreadPoolExecutor if we can't.
-                    this.serialTaskExecutor = new SerialExecutor(Executors.newFixedThreadPool(2));
-                }
-            }
-            return new TransferClient(this.context,
-                constraintsBuilder.build(),
-                this.serialTaskExecutor,
-                this.storageBlobClients);
         }
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferDatabase.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferDatabase.java
@@ -28,7 +28,10 @@ abstract class TransferDatabase extends RoomDatabase {
      * A singleton instance of {@link TransferDatabase}.
      */
     @Ignore
-    private static TransferDatabase db;
+    private static TransferDatabase INSTANCE;
+    // An object to synchronize the creation of the singleton TransferDatabase.
+    @Ignore
+    private static final Object INIT_LOCK = new Object();
 
     /**
      * Get the Data Access Object that exposes operations to store and retrieve upload
@@ -52,11 +55,13 @@ abstract class TransferDatabase extends RoomDatabase {
      * @return a shared {@link TransferDatabase} instance
      */
     @Ignore
-    synchronized static TransferDatabase get(Context context) {
-        if (db == null) {
-            db = Room.databaseBuilder(context,
-                TransferDatabase.class, "transfersDB").build();
+    static TransferDatabase getInstance(Context context) {
+        synchronized (INIT_LOCK) {
+            if (INSTANCE == null) {
+                INSTANCE = Room.databaseBuilder(context,
+                    TransferDatabase.class, "transfersDB").build();
+            }
+            return INSTANCE;
         }
-        return db;
     }
 }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveData.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveData.java
@@ -3,7 +3,6 @@
 
 package com.azure.android.storage.blob.transfer;
 
-import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.MainThread;
@@ -66,14 +65,14 @@ final class TransferIdInfoLiveData {
     private TransferIdInfoLiveData() {}
 
     @MainThread
-    static TransferIdInfoLiveData.Result create(Context context) {
+    static TransferIdInfoLiveData.Result create(WorkManager workManager) {
         TransferIdInfoLiveData transferIdInfoLiveData = new TransferIdInfoLiveData();
-        return transferIdInfoLiveData.init(context);
+        return transferIdInfoLiveData.init(workManager);
     }
 
-    private TransferIdInfoLiveData.Result init(@NonNull Context context) {
+    private TransferIdInfoLiveData.Result init(@NonNull WorkManager workManager) {
         // 1. Register mapping of transferId to LiveData<WorkInfo>
-        LiveData<WorkInfo> workInfoLiveData = this.mapInputTransferIdToWorkInfoLiveData(context);
+        LiveData<WorkInfo> workInfoLiveData = this.mapInputTransferIdToWorkInfoLiveData(workManager);
         // 2. Register mapping of LiveData<WorkInfo> to LiveData<TransferInfo>
         this.transferInfoLiveData.addSource(workInfoLiveData, workInfo -> {
             // The TransferInfo events generator.
@@ -246,10 +245,10 @@ final class TransferIdInfoLiveData {
      * worker that is processing the transfer identified by the transfer id emitted by
      * {@code transferIdOrErrorLiveData}.
      *
-     * @param context the context
+     * @param workManager reference to the {@link WorkManager} to retrieve WorkInfo
      * @return a LiveData of {@link WorkInfo}
      */
-    private LiveData<WorkInfo> mapInputTransferIdToWorkInfoLiveData(Context context) {
+    private LiveData<WorkInfo> mapInputTransferIdToWorkInfoLiveData(WorkManager workManager) {
         LiveData<List<WorkInfo>> workInfoListLiveData = Transformations
             .switchMap(
                 this.transferOpResultLiveData,
@@ -265,7 +264,7 @@ final class TransferIdInfoLiveData {
                         // No error from TransferClient i.e. transfer work may exists, get the underlying
                         // LiveData<WorkInfo> for the transfer work.
                         final long transferId = this.transferOperationResult.getId();
-                        return WorkManager.getInstance(context)
+                        return workManager
                             .getWorkInfosForUniqueWorkLiveData(TransferClient.toTransferUniqueWorkName(transferId));
                     }
                 }
@@ -408,7 +407,7 @@ final class TransferIdInfoLiveData {
     }
 
     /**
-     * Type representing result of {@link TransferIdInfoLiveData#create(Context)} method.
+     * Type representing result of {@link TransferIdInfoLiveData#create(WorkManager)} method.
      */
     final static class Result {
         private final LiveDataPair liveDataPair;

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferIdInfoLiveDataCache.java
@@ -3,12 +3,12 @@
 
 package com.azure.android.storage.blob.transfer;
 
-import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.MainThread;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.work.WorkManager;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
@@ -70,14 +70,14 @@ final class TransferIdInfoLiveDataCache {
      *
      * @param transferId the transferId to use as the key to identify the created LiveData
      *                   instances.
-     * @param context the context
+     * @param workManager reference to the {@link WorkManager} to retrieve WorkInfo.
      * @return the pair composing created {@code TransferOperationResult} LiveData and associated
      * {@code TransferInfo} LiveData
      */
     @MainThread
-    TransferIdInfoLiveData.LiveDataPair create(long transferId, Context context) {
+    TransferIdInfoLiveData.LiveDataPair create(long transferId, WorkManager workManager) {
         this.expunge();
-        final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(context);
+        final TransferIdInfoLiveData.Result result = TransferIdInfoLiveData.create(workManager);
         final TransferIdInfoLiveData.LiveDataPair liveDataPair = result.getLiveDataPair();
         this.map.put(transferId,
             new TransferInfoLiveDataWeakReference(liveDataPair.getTransferInfoLiveData(),
@@ -92,15 +92,15 @@ final class TransferIdInfoLiveDataCache {
      * Check whether the TransferOperationResult LiveData and the TransferInfo LiveData that is
      * identified by the given {@code transferId} key already exists in the cache, if it exists then
      * return the two LiveData in a {@Link TransferIdInfoLiveData#Pair}. If it does not exists then create,
-     * store and return them, see {@link TransferIdInfoLiveDataCache#create(long, Context)}
+     * store and return them, see {@link TransferIdInfoLiveDataCache#create(long, WorkManager)}
      * for more details.
      *
      * @param transferId the transferId to use as the key to identify the LiveData instances.
-     * @param context the context
+     * @param workManager reference to the {@link WorkManager} to retrieve WorkInfo.
      * @return the pair composing created TransferOperationResult LiveData and associated TransferInfo LiveData
      */
     @MainThread
-    TransferIdInfoLiveData.LiveDataPair getOrCreate(long transferId, Context context) {
+    TransferIdInfoLiveData.LiveDataPair getOrCreate(long transferId, WorkManager workManager) {
         this.expunge();
         final TransferInfoLiveDataWeakReference ref = this.map.get(transferId);
         if (ref != null) {
@@ -110,7 +110,7 @@ final class TransferIdInfoLiveDataCache {
                     transferInfoLiveData);
             }
         }
-        return create(transferId, context);
+        return create(transferId, workManager);
     }
 
     /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadHandler.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadHandler.java
@@ -17,7 +17,6 @@ import androidx.annotation.NonNull;
 import com.azure.android.core.http.ServiceCall;
 import com.azure.android.storage.blob.StorageBlobClient;
 import com.azure.android.storage.blob.models.BlockBlobItem;
-import com.azure.android.storage.blob.models.BlockBlobsStageBlockResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -146,7 +145,7 @@ final class UploadHandler extends Handler {
      * with the number of async operations equal to the configured blocksUploadConcurrency.
      */
     private void handleInit() {
-        this.db = TransferDatabase.get(this.appContext);
+        this.db = TransferDatabase.getInstance(this.appContext);
         this.blob = this.db.uploadDao().getBlob(uploadId);
         if (this.blob.interruptState == TransferInterruptState.PURGE) {
             this.transferHandlerListener.onError(new RuntimeException("Upload Operation with id '"

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadRequest.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadRequest.java
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.storage.blob.transfer;
+
+import android.content.Context;
+import android.net.Uri;
+
+import androidx.work.Constraints;
+
+import com.azure.android.core.util.CoreUtil;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * A type specifying parameters for upload transfer that should be enqueued in {@link TransferClient}.
+ */
+public final class UploadRequest {
+    private final String storageClientId;
+    private final String containerName;
+    private final String blobName;
+    private final ReadableContent readableContent;
+    private final Constraints constraints;
+
+    /**
+     * Create UploadRequest.
+     *
+     * @param storageClientId identifies the the blob storage client for the upload
+     * @param containerName the name of the container to upload the content to
+     * @param blobName  the name of the target blob holding uploaded content
+     * @param readableContent the object describing the content in the device that needs to be uploaded
+     * @param constraints the constraints to be satisfied to execute the upload
+     */
+    private UploadRequest(String storageClientId,
+                  String containerName,
+                  String blobName,
+                  ReadableContent readableContent,
+                  Constraints constraints) {
+        this.storageClientId = storageClientId;
+        this.containerName = containerName;
+        this.blobName = blobName;
+        this.readableContent = readableContent;
+        this.constraints = constraints;
+    }
+
+    /**
+     * Get the unique identifier of the blob storage client to be used for the upload.
+     *
+     * @return the unique identifier of the blob storage client
+     */
+    String getStorageClientId() {
+        return this.storageClientId;
+    }
+
+    /**
+     * Get the name of the container to upload the file to.
+     *
+     * @return the container name
+     */
+    String getContainerName() {
+        return this.containerName;
+    }
+
+    /**
+     * Get the name of the target blob holding uploaded file.
+     *
+     * @return the blob name
+     */
+    String getBlobName() {
+        return this.blobName;
+    }
+
+    /**
+     * Get the object describing the content in the device that needs to be uploaded.
+     *
+     * @return the content description
+     */
+    ReadableContent getReadableContent() {
+        return this.readableContent;
+    }
+
+    /**
+     * Get the constraints to be satisfied to execute the upload.
+     *
+     * @return the constraints
+     */
+    Constraints getConstraints() {
+        return this.constraints;
+    }
+
+    /**
+     * Builder for {@link UploadRequest}.
+     */
+    public static final class Builder {
+        private String storageClientId;
+        private String containerName;
+        private String blobName;
+        private ReadableContent readableContent;
+        private Constraints constraints;
+
+        /**
+         * Creates a {@link Builder}.
+         */
+        public Builder() {
+        }
+
+        /**
+         * Set the unique identifier of the blob storage client to be used for the upload.
+         *
+         * @param storageClientId the blob storage client id
+         * @return Builder with provided blob storage client id set
+         */
+        public Builder storageClientId(String storageClientId) {
+            this.storageClientId = storageClientId;
+            return this;
+        }
+
+        /**
+         * Set the name of the container to upload the file to.
+         *
+         * @param containerName the container name
+         * @return Builder with provided container name set
+         */
+        public Builder containerName(String containerName) {
+            this.containerName = containerName;
+            return this;
+        }
+
+        /**
+         * Set the name of the target blob holding uploaded file.
+         *
+         * @param blobName the blob name
+         * @return Builder with provided blob name set
+         */
+        public Builder blobName(String blobName) {
+            this.blobName = blobName;
+            return this;
+        }
+
+        /**
+         * Set the file in the device to upload.
+         *
+         * @param file the file
+         * @return Builder with provided file set
+         */
+        public Builder file(File file) {
+            Objects.requireNonNull(file, "'file' cannot be null.");
+            if (this.readableContent != null && this.readableContent.isUsingContentResolver()) {
+                throw new IllegalArgumentException("Both the contentUri and file cannot be set for the same request.");
+            }
+            this.readableContent = new ReadableContent(null, Uri.fromFile(file), false);
+            return this;
+        }
+
+        /**
+         * Set the content in the device to upload.
+         *
+         * @param context the application context
+         * @param uri URI to the Content to upload
+         * @return Builder with provided content description set
+         */
+        public Builder contentUri(Context context, Uri uri) {
+            Objects.requireNonNull(context, "'context' cannot be null.");
+            Objects.requireNonNull(uri, "'uri' cannot be null.");
+            if (this.readableContent != null && !this.readableContent.isUsingContentResolver()) {
+                throw new IllegalArgumentException("Both the contentUri and file cannot be set for the same request.");
+            }
+            this.readableContent = new ReadableContent(context, uri, true);
+            return this;
+        }
+
+        /**
+         * Set the constraints to be satisfied to execute the upload.
+         *
+         * @param constraints the constraints
+         * @return Builder with provided constraints set
+         */
+        public Builder constraints(Constraints constraints) {
+            this.constraints = constraints;
+            return this;
+        }
+
+        /**
+         * Builds a {@link UploadRequest} based on this {@link Builder}'s configuration.
+         *
+         * @return A {@link UploadRequest}.
+         */
+        public UploadRequest build() {
+            if (CoreUtil.isNullOrEmpty(this.storageClientId)) {
+                throw new IllegalArgumentException("'storageClientId' is required and cannot be null or empty.");
+            }
+            if (CoreUtil.isNullOrEmpty(this.containerName)) {
+                throw new IllegalArgumentException("'containerName' is required and cannot be null or empty.");
+            }
+            if (CoreUtil.isNullOrEmpty(this.blobName)) {
+                throw new IllegalArgumentException("'blobName' is required and cannot be null or empty.");
+            }
+            Objects.requireNonNull(this.readableContent, "either 'file' or 'contentUri' must be set.");
+            Objects.requireNonNull(this.constraints, "'constraints' cannot be null.");
+            return new UploadRequest(this.storageClientId,
+                this.containerName,
+                this.blobName,
+                this.readableContent,
+                this.constraints);
+        }
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadRequest.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/UploadRequest.java
@@ -14,7 +14,7 @@ import java.io.File;
 import java.util.Objects;
 
 /**
- * A type specifying parameters for upload transfer that should be enqueued in {@link TransferClient}.
+ * A type specifying parameters for an upload transfer that should be enqueued in {@link TransferClient}.
  */
 public final class UploadRequest {
     private final String storageClientId;
@@ -26,17 +26,17 @@ public final class UploadRequest {
     /**
      * Create UploadRequest.
      *
-     * @param storageClientId identifies the the blob storage client for the upload
-     * @param containerName the name of the container to upload the content to
-     * @param blobName  the name of the target blob holding uploaded content
-     * @param readableContent the object describing the content in the device that needs to be uploaded
-     * @param constraints the constraints to be satisfied to execute the upload
+     * @param storageClientId Identifies the {@link com.azure.android.storage.blob.StorageBlobClient} for the upload.
+     * @param containerName   The name of the container to upload the content to.
+     * @param blobName        The name of the target blob holding the uploaded content.
+     * @param readableContent The object describing the content in the device that needs to be uploaded.
+     * @param constraints     The constraints to be satisfied to execute the upload.
      */
     private UploadRequest(String storageClientId,
-                  String containerName,
-                  String blobName,
-                  ReadableContent readableContent,
-                  Constraints constraints) {
+                          String containerName,
+                          String blobName,
+                          ReadableContent readableContent,
+                          Constraints constraints) {
         this.storageClientId = storageClientId;
         this.containerName = containerName;
         this.blobName = blobName;
@@ -47,7 +47,7 @@ public final class UploadRequest {
     /**
      * Get the unique identifier of the blob storage client to be used for the upload.
      *
-     * @return the unique identifier of the blob storage client
+     * @return The unique identifier of the {@link com.azure.android.storage.blob.StorageBlobClient}.
      */
     String getStorageClientId() {
         return this.storageClientId;
@@ -56,7 +56,7 @@ public final class UploadRequest {
     /**
      * Get the name of the container to upload the file to.
      *
-     * @return the container name
+     * @return The container name.
      */
     String getContainerName() {
         return this.containerName;
@@ -65,7 +65,7 @@ public final class UploadRequest {
     /**
      * Get the name of the target blob holding uploaded file.
      *
-     * @return the blob name
+     * @return The blob name.
      */
     String getBlobName() {
         return this.blobName;
@@ -74,7 +74,7 @@ public final class UploadRequest {
     /**
      * Get the object describing the content in the device that needs to be uploaded.
      *
-     * @return the content description
+     * @return The content description.
      */
     ReadableContent getReadableContent() {
         return this.readableContent;
@@ -83,7 +83,7 @@ public final class UploadRequest {
     /**
      * Get the constraints to be satisfied to execute the upload.
      *
-     * @return the constraints
+     * @return The constraints.
      */
     Constraints getConstraints() {
         return this.constraints;
@@ -108,8 +108,8 @@ public final class UploadRequest {
         /**
          * Set the unique identifier of the blob storage client to be used for the upload.
          *
-         * @param storageClientId the blob storage client id
-         * @return Builder with provided blob storage client id set
+         * @param storageClientId The blob storage client ID.
+         * @return Builder with the provided blob storage client ID set.
          */
         public Builder storageClientId(String storageClientId) {
             this.storageClientId = storageClientId;
@@ -119,8 +119,8 @@ public final class UploadRequest {
         /**
          * Set the name of the container to upload the file to.
          *
-         * @param containerName the container name
-         * @return Builder with provided container name set
+         * @param containerName The container name.
+         * @return Builder with the provided container name set.
          */
         public Builder containerName(String containerName) {
             this.containerName = containerName;
@@ -128,10 +128,10 @@ public final class UploadRequest {
         }
 
         /**
-         * Set the name of the target blob holding uploaded file.
+         * Set the name of the target blob holding the uploaded file.
          *
-         * @param blobName the blob name
-         * @return Builder with provided blob name set
+         * @param blobName The blob name.
+         * @return Builder with the provided blob name set.
          */
         public Builder blobName(String blobName) {
             this.blobName = blobName;
@@ -139,10 +139,10 @@ public final class UploadRequest {
         }
 
         /**
-         * Set the file in the device to upload.
+         * Set the local file to upload.
          *
-         * @param file the file
-         * @return Builder with provided file set
+         * @param file The file.
+         * @return Builder with the provided file set.
          */
         public Builder file(File file) {
             Objects.requireNonNull(file, "'file' cannot be null.");
@@ -154,11 +154,11 @@ public final class UploadRequest {
         }
 
         /**
-         * Set the content in the device to upload.
+         * Set the content in the device to upload from.
          *
-         * @param context the application context
-         * @param uri URI to the Content to upload
-         * @return Builder with provided content description set
+         * @param context The application context.
+         * @param uri     The URI to the local content to upload.
+         * @return Builder with the provided content description set.
          */
         public Builder contentUri(Context context, Uri uri) {
             Objects.requireNonNull(context, "'context' cannot be null.");
@@ -173,8 +173,8 @@ public final class UploadRequest {
         /**
          * Set the constraints to be satisfied to execute the upload.
          *
-         * @param constraints the constraints
-         * @return Builder with provided constraints set
+         * @param constraints The constraints.
+         * @return Builder with the provided constraints set.
          */
         public Builder constraints(Constraints constraints) {
             this.constraints = constraints;
@@ -184,7 +184,7 @@ public final class UploadRequest {
         /**
          * Builds a {@link UploadRequest} based on this {@link Builder}'s configuration.
          *
-         * @return A {@link UploadRequest}.
+         * @return An {@link UploadRequest}.
          */
         public UploadRequest build() {
             if (CoreUtil.isNullOrEmpty(this.storageClientId)) {

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/android/storage/blob/StorageBlobClientTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/android/storage/blob/StorageBlobClientTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertNull;
 public class StorageBlobClientTest {
     private static final MockWebServer mockWebServer = new MockWebServer();
     private static final String BASE_URL = mockWebServer.url("/").toString();
-    private static StorageBlobClient storageBlobClient = new StorageBlobClient.Builder(
+    private static StorageBlobClient storageBlobClient = new StorageBlobClient.Builder("client.test.1",
         new ServiceClient.Builder()
             .setBaseUrl(BASE_URL)
             .setSerializationFormat(SerializerFormat.XML))
@@ -55,7 +55,7 @@ public class StorageBlobClientTest {
         // Given a StorageBlobClient.
 
         // When creating another client based on the first one.
-        StorageBlobClient otherStorageBlobClient = storageBlobClient.newBuilder().build();
+        StorageBlobClient otherStorageBlobClient = storageBlobClient.newBuilder("client.test.2").build();
 
         // Then the new client will contain the same properties as the original.
         assertEquals(storageBlobClient.getBlobServiceUrl(), otherStorageBlobClient.getBlobServiceUrl());


### PR DESCRIPTION
This PR updates the `StorageBlobClient` to expose transfer APIs (upload, download, pause, resume, cancel).

The `StorageClient.Builder` now allows setting the transfer constraints. Below shows how to create `StorageBlobClient`.

```java
StorageBlobClient client1 = new StorageBlobClient
    .Builder("com.azure.android.storage.sample")
        .setBlobServiceUrl(storageConfiguration.getBlobServiceUrl())
        .setRequiredNetworkType(NetworkType.CONNECTED)
        .build();
```
Note that the builder constructor now takes the "storage client id" that uniquely identifies the `StorageBlobClient` this builder creates. As part of executing `build()` it adds the created `StorageBlobClient` to the global map.

We continue to support creating a new `StorageBlobClient` from an existing client:

```java
StorageBlobClient client2 = client1
    .newBuilder("com.azure.android.storage.sample.upload")
        .setCredentialInterceptor(authInterceptor)
        .setRequiresBatteryNotLow(true)
        .build();
```

`TransferClient` has been updated to have a singleton instance. It is retrieve as: 

```java
TransferClient transferClient = TransferClient.getInstance(context);    
```

This is similar to the way we get WorkManager:

```java
WorkManager workManager = WorkManager.getInstance(context);
```

A `TransferClient` instance will not hold a reference to the context. Some read on the subject tells its a bad idea to keep context, so, like `WorkManager`, `TransferClient` uses the context for initialization and release it.

Some notes on the PR:

1. We want to hide `TransferClient` for preview1, which means `TransferClient` and `StorageBlobClient` may have to exist in the same package. This PR won't move files around for this; just want this PR to highlight the concept, logic, API changes for easy review.

2. There are two new types `UploadRequest`|`DownloadRequest`; it is easy to merge these two but didn't do it - just following the existing design of separate internal types for upload|download. Also, these types are anyway going to be internal once `#1` is addressed.