### PR TITLE
Porting Fluent|Immutable annoations from Java SDK

### DIFF
--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/Fluent.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/Fluent.java
@@ -1,0 +1,22 @@
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * Annotation given to all classes that are expected to provide a fluent API to end users. If a class has this
+ * annotation, checks can be made to ensure all API meets this expectation. Similarly, classes that are not annotated
+ * with this annotation should not have fluent APIs.
+ */
+@Retention(SOURCE)
+@Target(TYPE)
+public @interface Fluent {
+
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/Immutable.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/annotation/Immutable.java
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.annotation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation given to all immutable classes. If a class has this annotation, checks can be made to ensure all
+ * fields in this class are final.
+ */
+@Retention(SOURCE)
+@Target(TYPE)
+public @interface Immutable {
+
+}


### PR DESCRIPTION
Copying over the guideline defined annotations from Java SDK to Android. 

The generated code will have these annotations, eventually, we should also have it for any applicable convenience types. This has no runtime overhead, mainly will be used by checkstyle once we have it.
