### PR TITLE
Adding callbackWithHeader and updating callback signature to include Response

### DIFF
--- a/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ContainerBlobsPaginationRepository.java
+++ b/samples/sample-app-storage/src/main/java/com/azure/android/storage/sample/ContainerBlobsPaginationRepository.java
@@ -8,7 +8,7 @@ import com.azure.android.core.http.Callback;
 import com.azure.android.core.util.CancellationToken;
 import com.azure.android.storage.blob.StorageBlobAsyncClient;
 import com.azure.android.storage.blob.models.BlobItem;
-import com.azure.android.storage.blob.models.ContainersListBlobFlatSegmentResponse;
+import com.azure.android.storage.blob.models.BlobsPage;
 import com.azure.android.storage.blob.models.ListBlobsOptions;
 import com.azure.android.storage.sample.core.util.paging.DefaultPaginationDescription;
 import com.azure.android.storage.sample.core.util.paging.PageItemsFetcher;
@@ -16,9 +16,10 @@ import com.azure.android.storage.sample.core.util.paging.PaginationDescription;
 import com.azure.android.storage.sample.core.util.paging.PaginationDescriptionRepository;
 import com.azure.android.storage.sample.core.util.paging.PaginationOptions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import okhttp3.Response;
 
 /**
  * PACKAGE PRIVATE TYPE.
@@ -60,22 +61,21 @@ final class ContainerBlobsPaginationRepository
                 if (pageSize != null && pageSize > 0) {
                     options.setMaxResultsPerPage(pageSize);
                 }
-                storageBlobAsyncClient.getBlobsInPageWithRestResponse(pageIdentifier, containerName, options.getPrefix(),
-                        options.getMaxResultsPerPage(), options.getDetails().toList(),
-                        null, null, CancellationToken.NONE, new Callback<ContainersListBlobFlatSegmentResponse>() {
-                            @Override
-                            public void onResponse(ContainersListBlobFlatSegmentResponse response) {
-                                List<BlobItem> value = response.getValue().getSegment() == null
-                                        ? new ArrayList<>(0)
-                                       : response.getValue().getSegment().getBlobItems();
-                               callback.onSuccess(value, response.getValue().getMarker(), response.getValue().getNextMarker());
-                           }
-
-                         @Override
-                            public void onFailure(Throwable t) {
-                            callback.onFailure(t);
+                storageBlobAsyncClient.getBlobsInPage(pageIdentifier, containerName, options.getPrefix(),
+                    options.getMaxResultsPerPage(), options.getDetails().toList(),
+                    null, null, CancellationToken.NONE,
+                    new Callback<BlobsPage>() {
+                        @Override
+                        public void onSuccess(BlobsPage result, Response response) {
+                            List<BlobItem> value = result.getItems();
+                            callback.onSuccess(value, result.getPageId(), result.getNextPageId());
                         }
-                 });
+
+                        @Override
+                        public void onFailure(Throwable throwable, Response response) {
+                            callback.onFailure(throwable);
+                        }
+                    });
             }
         };
         return DefaultPaginationDescription.create(pageItemsFetcher, this.paginationOptions);

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/Callback.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/Callback.java
@@ -21,7 +21,7 @@ public interface Callback<T> {
      * The method to call on failure.
      *
      * @param throwable A throwable with the failure details.
-     * @param response  The response, if available for the failure.
+     * @param response  The response for the failure, if available.
      */
     void onFailure(Throwable throwable, okhttp3.Response response);
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/CallbackWithHeader.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/CallbackWithHeader.java
@@ -23,7 +23,7 @@ public interface CallbackWithHeader<T, H> {
      * The method to call on failure.
      *
      * @param throwable A throwable with the failure details.
-     * @param response  The response, if available for the failure.
+     * @param response  The response for the failure, if available.
      */
     void onFailure(Throwable throwable, okhttp3.Response response);
 }

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/CallbackWithHeader.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/CallbackWithHeader.java
@@ -7,15 +7,17 @@ package com.azure.android.core.http;
  * Callback to receive a service operation result.
  *
  * @param <T> The type of the result.
+ * @param <T> The type of the header.
  */
-public interface Callback<T> {
+public interface CallbackWithHeader<T, H> {
     /**
      * The method to call on a successful result.
      *
      * @param result   The result.
+     * @param header   The custom header value.
      * @param response The response.
      */
-    void onSuccess(T result, okhttp3.Response response);
+    void onSuccess(T result, H header, okhttp3.Response response);
 
     /**
      * The method to call on failure.

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobAsyncClient.java
@@ -14,26 +14,28 @@ import androidx.work.Constraints;
 import androidx.work.NetworkType;
 
 import com.azure.android.core.http.Callback;
+import com.azure.android.core.http.CallbackWithHeader;
 import com.azure.android.core.http.ServiceClient;
 import com.azure.android.core.http.interceptor.AddDateInterceptor;
 import com.azure.android.core.internal.util.serializer.SerializerFormat;
 import com.azure.android.core.util.CancellationToken;
 import com.azure.android.core.util.CoreUtil;
 import com.azure.android.storage.blob.models.AccessTier;
-import com.azure.android.storage.blob.models.BlobDeleteResponse;
-import com.azure.android.storage.blob.models.BlobDownloadResponse;
+import com.azure.android.storage.blob.models.BlobDeleteHeaders;
+import com.azure.android.storage.blob.models.BlobDownloadHeaders;
 import com.azure.android.storage.blob.models.BlobGetPropertiesHeaders;
 import com.azure.android.storage.blob.models.BlobHttpHeaders;
 import com.azure.android.storage.blob.models.BlobItem;
 import com.azure.android.storage.blob.models.BlobRange;
 import com.azure.android.storage.blob.models.BlobRequestConditions;
-import com.azure.android.storage.blob.models.BlobGetPropertiesResponse;
+import com.azure.android.storage.blob.models.BlobsPage;
+import com.azure.android.storage.blob.models.BlockBlobCommitBlockListHeaders;
 import com.azure.android.storage.blob.models.BlockBlobItem;
-import com.azure.android.storage.blob.models.BlockBlobsCommitBlockListResponse;
-import com.azure.android.storage.blob.models.BlockBlobsStageBlockResponse;
-import com.azure.android.storage.blob.models.ContainersListBlobFlatSegmentResponse;
+import com.azure.android.storage.blob.models.BlockBlobStageBlockHeaders;
+import com.azure.android.storage.blob.models.ListBlobFlatSegmentHeaders;
 import com.azure.android.storage.blob.models.CpkInfo;
 import com.azure.android.storage.blob.models.DeleteSnapshotsOptionType;
+import com.azure.android.storage.blob.models.ListBlobsFlatSegmentResponse;
 import com.azure.android.storage.blob.models.ListBlobsIncludeItem;
 import com.azure.android.storage.blob.models.ListBlobsOptions;
 import com.azure.android.storage.blob.transfer.DownloadRequest;
@@ -45,11 +47,13 @@ import com.azure.android.storage.blob.transfer.UploadRequest;
 import org.threeten.bp.OffsetDateTime;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import okhttp3.Interceptor;
+import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 /**
@@ -244,11 +248,24 @@ public class StorageBlobAsyncClient {
     public void getBlobsInPage(String pageId,
                                String containerName,
                                ListBlobsOptions options,
-                               Callback<List<BlobItem>> callback) {
-        this.storageBlobServiceClient.getBlobsInPage(pageId,
+                               Callback<BlobsPage> callback) {
+        this.storageBlobServiceClient.listBlobFlatSegment(pageId,
             containerName,
             options,
-            callback);
+            new CallbackWithHeader<ListBlobsFlatSegmentResponse, ListBlobFlatSegmentHeaders>() {
+                @Override
+                public void onSuccess(ListBlobsFlatSegmentResponse result, ListBlobFlatSegmentHeaders header, Response response) {
+                    List<BlobItem> list = result.getSegment() == null
+                        ? new ArrayList<>(0)
+                        : result.getSegment().getBlobItems();
+                    callback.onSuccess(new BlobsPage(list, pageId, result.getNextMarker()), response);
+                }
+
+                @Override
+                public void onFailure(Throwable throwable, Response response) {
+                    callback.onFailure(throwable, response);
+                }
+            });
     }
 
     /**
@@ -266,16 +283,16 @@ public class StorageBlobAsyncClient {
      * @param callback          Callback that receives the response.
      * @param cancellationToken The token to request cancellation.
      */
-    public void getBlobsInPageWithRestResponse(String pageId,
-                                               String containerName,
-                                               String prefix,
-                                               Integer maxResults,
-                                               List<ListBlobsIncludeItem> include,
-                                               Integer timeout,
-                                               String requestId,
-                                               CancellationToken cancellationToken,
-                                               Callback<ContainersListBlobFlatSegmentResponse> callback) {
-        this.storageBlobServiceClient.getBlobsInPageWithRestResponse(pageId,
+    public void getBlobsInPage(String pageId,
+                               String containerName,
+                               String prefix,
+                               Integer maxResults,
+                               List<ListBlobsIncludeItem> include,
+                               Integer timeout,
+                               String requestId,
+                               CancellationToken cancellationToken,
+                               Callback<BlobsPage> callback) {
+        this.storageBlobServiceClient.listBlobFlatSegment(pageId,
             containerName,
             prefix,
             maxResults,
@@ -283,7 +300,20 @@ public class StorageBlobAsyncClient {
             timeout,
             requestId,
             cancellationToken,
-            callback);
+            new CallbackWithHeader<ListBlobsFlatSegmentResponse, ListBlobFlatSegmentHeaders>() {
+                @Override
+                public void onSuccess(ListBlobsFlatSegmentResponse result, ListBlobFlatSegmentHeaders header, Response response) {
+                    List<BlobItem> list = result.getSegment() == null
+                        ? new ArrayList<>(0)
+                        : result.getSegment().getBlobItems();
+                    callback.onSuccess(new BlobsPage(list, pageId, result.getNextMarker()), response);
+                }
+
+                @Override
+                public void onFailure(Throwable throwable, Response response) {
+                    callback.onFailure(throwable, response);
+                }
+            });
     }
 
     /**
@@ -295,7 +325,7 @@ public class StorageBlobAsyncClient {
      */
     public void getBlobProperties(String containerName,
                                   String blobName,
-                                  Callback<BlobGetPropertiesHeaders> callback) {
+                                  CallbackWithHeader<Void, BlobGetPropertiesHeaders> callback) {
         storageBlobServiceClient.getBlobProperties(containerName,
             blobName,
             callback);
@@ -321,19 +351,19 @@ public class StorageBlobAsyncClient {
      * @param cancellationToken     The token to request cancellation.
      * @param callback              Callback that receives the response.
      */
-    public void getBlobPropertiesWithRestResponse(String containerName,
-                                                  String blobName,
-                                                  String snapshot,
-                                                  Integer timeout,
-                                                  String version,
-                                                  BlobRequestConditions blobRequestConditions,
-                                                  String requestId,
-                                                  CpkInfo cpkInfo,
-                                                  CancellationToken cancellationToken,
-                                                  Callback<BlobGetPropertiesResponse> callback) {
+    public void getBlobProperties(String containerName,
+                                  String blobName,
+                                  String snapshot,
+                                  Integer timeout,
+                                  String version,
+                                  BlobRequestConditions blobRequestConditions,
+                                  String requestId,
+                                  CpkInfo cpkInfo,
+                                  CancellationToken cancellationToken,
+                                  CallbackWithHeader<Void, BlobGetPropertiesHeaders> callback) {
         blobRequestConditions = blobRequestConditions == null ? new BlobRequestConditions() : blobRequestConditions;
 
-        storageBlobServiceClient.getBlobPropertiesWithRestResponse(containerName,
+        storageBlobServiceClient.getBlobProperties(containerName,
             blobName,
             snapshot,
             timeout,
@@ -361,7 +391,7 @@ public class StorageBlobAsyncClient {
      */
     public void rawDownload(String containerName,
                             String blobName,
-                            Callback<ResponseBody> callback) {
+                            CallbackWithHeader<ResponseBody, BlobDownloadHeaders> callback) {
         storageBlobServiceClient.download(containerName,
             blobName,
             callback);
@@ -398,23 +428,23 @@ public class StorageBlobAsyncClient {
      * @param cancellationToken     The token to request cancellation.
      * @param callback              Callback that receives the response.
      */
-    public void rawDownloadWithRestResponse(String containerName,
-                                            String blobName,
-                                            String snapshot,
-                                            Integer timeout,
-                                            BlobRange range,
-                                            BlobRequestConditions blobRequestConditions,
-                                            Boolean getRangeContentMd5,
-                                            Boolean getRangeContentCrc64,
-                                            String version,
-                                            String requestId,
-                                            CpkInfo cpkInfo,
-                                            CancellationToken cancellationToken,
-                                            Callback<BlobDownloadResponse> callback) {
+    public void rawDownload(String containerName,
+                            String blobName,
+                            String snapshot,
+                            Integer timeout,
+                            BlobRange range,
+                            BlobRequestConditions blobRequestConditions,
+                            Boolean getRangeContentMd5,
+                            Boolean getRangeContentCrc64,
+                            String version,
+                            String requestId,
+                            CpkInfo cpkInfo,
+                            CancellationToken cancellationToken,
+                            CallbackWithHeader<ResponseBody, BlobDownloadHeaders> callback) {
         range = range == null ? new BlobRange(0) : range;
         blobRequestConditions = blobRequestConditions == null ? new BlobRequestConditions() : blobRequestConditions;
 
-        storageBlobServiceClient.downloadWithRestResponse(containerName,
+        storageBlobServiceClient.rawDownload(containerName,
             blobName,
             snapshot,
             timeout,
@@ -450,7 +480,7 @@ public class StorageBlobAsyncClient {
                            String base64BlockId,
                            byte[] blockContent,
                            byte[] contentMd5,
-                           Callback<Void> callback) {
+                           CallbackWithHeader<Void, BlockBlobStageBlockHeaders> callback) {
         this.storageBlobServiceClient.stageBlock(containerName,
             blobName,
             base64BlockId,
@@ -479,19 +509,19 @@ public class StorageBlobAsyncClient {
      * @param cancellationToken The token to request cancellation.
      * @param callback          Callback that receives the response.
      */
-    public void stageBlockWithRestResponse(String containerName,
-                                           String blobName,
-                                           String base64BlockId,
-                                           byte[] blockContent,
-                                           byte[] contentMd5,
-                                           byte[] contentCrc64,
-                                           Integer timeout,
-                                           String leaseId,
-                                           String requestId,
-                                           CpkInfo cpkInfo,
-                                           CancellationToken cancellationToken,
-                                           Callback<BlockBlobsStageBlockResponse> callback) {
-        this.storageBlobServiceClient.stageBlockWithRestResponse(containerName,
+    public void stageBlock(String containerName,
+                           String blobName,
+                           String base64BlockId,
+                           byte[] blockContent,
+                           byte[] contentMd5,
+                           byte[] contentCrc64,
+                           Integer timeout,
+                           String leaseId,
+                           String requestId,
+                           CpkInfo cpkInfo,
+                           CancellationToken cancellationToken,
+                           CallbackWithHeader<Void, BlockBlobStageBlockHeaders> callback) {
+        this.storageBlobServiceClient.stageBlock(containerName,
             blobName,
             base64BlockId,
             blockContent,
@@ -508,7 +538,7 @@ public class StorageBlobAsyncClient {
     /**
      * The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob.
      * For a block to be written as part of a blob, the block must have been successfully written to the server in a prior
-     * {@link StorageBlobAsyncClient#stageBlock(String, String, String, byte[], byte[], Callback)} operation. You can
+     * {@link StorageBlobAsyncClient#stageBlock(String, String, String, byte[], byte[], CallbackWithHeader)}. You can
      * call commit Block List to update a blob by uploading only those blocks that have changed, then committing the new
      * and existing blocks together. You can do this by specifying whether to commit a block from the committed block
      * list or from the uncommitted block list, or to commit the most recently uploaded version of the block,
@@ -524,7 +554,7 @@ public class StorageBlobAsyncClient {
                                 String blobName,
                                 List<String> base64BlockIds,
                                 boolean overwrite,
-                                Callback<BlockBlobItem> callback) {
+                                CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders> callback) {
         this.storageBlobServiceClient.commitBlockList(containerName,
             blobName,
             base64BlockIds,
@@ -535,7 +565,7 @@ public class StorageBlobAsyncClient {
     /**
      * The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob.
      * For a block to be written as part of a blob, the block must have been successfully written to the server in a prior
-     * {@link StorageBlobAsyncClient#stageBlock(String, String, String, byte[], byte[], Callback)} operation. You can call
+     * {@link StorageBlobAsyncClient#stageBlock(String, String, String, byte[], byte[], CallbackWithHeader)}  operation. You can call
      * commit Block List to update a blob by uploading only those blocks that have changed, then committing the new and existing
      * blocks together. You can do this by specifying whether to commit a block from the committed block list or from
      * the uncommitted block list, or to commit the most recently uploaded version of the block, whichever list it may belong to.
@@ -557,21 +587,21 @@ public class StorageBlobAsyncClient {
      * @param cancellationToken The token to request cancellation.
      * @param callback          Callback that receives the response.
      */
-    public void commitBlockListWithRestResponse(String containerName,
-                                                String blobName,
-                                                List<String> base64BlockIds,
-                                                byte[] contentMD5,
-                                                byte[] contentCrc64,
-                                                Integer timeout,
-                                                BlobHttpHeaders blobHttpHeaders,
-                                                Map<String, String> metadata,
-                                                BlobRequestConditions requestConditions,
-                                                String requestId,
-                                                CpkInfo cpkInfo,
-                                                AccessTier tier,
-                                                CancellationToken cancellationToken,
-                                                Callback<BlockBlobsCommitBlockListResponse> callback) {
-        this.storageBlobServiceClient.commitBlockListWithRestResponse(containerName,
+    public void commitBlockList(String containerName,
+                                String blobName,
+                                List<String> base64BlockIds,
+                                byte[] contentMD5,
+                                byte[] contentCrc64,
+                                Integer timeout,
+                                BlobHttpHeaders blobHttpHeaders,
+                                Map<String, String> metadata,
+                                BlobRequestConditions requestConditions,
+                                String requestId,
+                                CpkInfo cpkInfo,
+                                AccessTier tier,
+                                CancellationToken cancellationToken,
+                                CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders> callback) {
+        this.storageBlobServiceClient.commitBlockList(containerName,
             blobName,
             base64BlockIds,
             contentMD5,
@@ -596,7 +626,7 @@ public class StorageBlobAsyncClient {
      */
     void delete(String containerName,
                 String blobName,
-                Callback<Void> callback) {
+                CallbackWithHeader<Void, BlobDeleteHeaders> callback) {
         storageBlobServiceClient.delete(containerName,
             blobName,
             callback);
@@ -642,21 +672,21 @@ public class StorageBlobAsyncClient {
      * @param cancellationToken The token to request cancellation.
      * @param callback          Callback that receives the response.
      */
-    void deleteWithResponse(String containerName,
-                            String blobName,
-                            String snapshot,
-                            Integer timeout,
-                            String version,
-                            String leaseId,
-                            DeleteSnapshotsOptionType deleteSnapshots,
-                            OffsetDateTime ifModifiedSince,
-                            OffsetDateTime ifUnmodifiedSince,
-                            String ifMatch,
-                            String ifNoneMatch,
-                            String requestId,
-                            CancellationToken cancellationToken,
-                            Callback<BlobDeleteResponse> callback) {
-        storageBlobServiceClient.deleteWithResponse(containerName,
+    void delete(String containerName,
+                String blobName,
+                String snapshot,
+                Integer timeout,
+                String version,
+                String leaseId,
+                DeleteSnapshotsOptionType deleteSnapshots,
+                OffsetDateTime ifModifiedSince,
+                OffsetDateTime ifUnmodifiedSince,
+                String ifMatch,
+                String ifNoneMatch,
+                String requestId,
+                CancellationToken cancellationToken,
+                CallbackWithHeader<Void, BlobDeleteHeaders> callback) {
+        storageBlobServiceClient.delete(containerName,
             blobName,
             snapshot,
             timeout,

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
@@ -6,6 +6,7 @@ package com.azure.android.storage.blob;
 import android.content.Context;
 import android.net.Uri;
 
+import com.azure.android.core.http.Response;
 import com.azure.android.core.http.ServiceClient;
 import com.azure.android.core.http.interceptor.AddDateInterceptor;
 import com.azure.android.core.internal.util.serializer.SerializerFormat;
@@ -19,18 +20,21 @@ import com.azure.android.storage.blob.models.BlobItem;
 import com.azure.android.storage.blob.models.BlobRange;
 import com.azure.android.storage.blob.models.BlobRequestConditions;
 import com.azure.android.storage.blob.models.BlobGetPropertiesResponse;
+import com.azure.android.storage.blob.models.BlobsPage;
 import com.azure.android.storage.blob.models.BlockBlobItem;
 import com.azure.android.storage.blob.models.BlockBlobsCommitBlockListResponse;
 import com.azure.android.storage.blob.models.BlockBlobsStageBlockResponse;
 import com.azure.android.storage.blob.models.ContainersListBlobFlatSegmentResponse;
 import com.azure.android.storage.blob.models.CpkInfo;
 import com.azure.android.storage.blob.models.DeleteSnapshotsOptionType;
+import com.azure.android.storage.blob.models.ListBlobsFlatSegmentResponse;
 import com.azure.android.storage.blob.models.ListBlobsIncludeItem;
 import com.azure.android.storage.blob.models.ListBlobsOptions;
 
 import org.threeten.bp.OffsetDateTime;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,12 +83,20 @@ public class StorageBlobClient {
      * @param options       The page options.
      * @return A list of blobs.
      */
-    public List<BlobItem> getBlobsInPage(String pageId,
-                                         String containerName,
-                                         ListBlobsOptions options) {
-        return this.storageBlobServiceClient.getBlobsInPage(pageId,
-            containerName,
-            options);
+    public BlobsPage getBlobsInPage(String pageId,
+                                    String containerName,
+                                    ListBlobsOptions options) {
+        ListBlobsFlatSegmentResponse result = this.storageBlobServiceClient.listBlobFlatSegment(pageId,
+            containerName, options);
+
+        final List<BlobItem> list;
+        if (result.getSegment() != null
+            && result.getSegment().getBlobItems() != null) {
+            list = result.getSegment().getBlobItems();
+        } else {
+            list = new ArrayList<>(0);
+        }
+        return new BlobsPage(list, pageId, result.getNextMarker());
     }
 
     /**
@@ -102,15 +114,16 @@ public class StorageBlobClient {
      * @param cancellationToken The token to request cancellation.
      * @return A response object containing a list of blobs.
      */
-    public ContainersListBlobFlatSegmentResponse getBlobsInPageWithRestResponse(String pageId,
-                                                                                String containerName,
-                                                                                String prefix,
-                                                                                Integer maxResults,
-                                                                                List<ListBlobsIncludeItem> include,
-                                                                                Integer timeout,
-                                                                                String requestId,
-                                                                                CancellationToken cancellationToken) {
-        return this.storageBlobServiceClient.getBlobsInPageWithRestResponse(pageId,
+    public Response<BlobsPage> getBlobsInPageWithRestResponse(String pageId,
+                                                              String containerName,
+                                                              String prefix,
+                                                              Integer maxResults,
+                                                              List<ListBlobsIncludeItem> include,
+                                                              Integer timeout,
+                                                              String requestId,
+                                                              CancellationToken cancellationToken) {
+        ContainersListBlobFlatSegmentResponse result
+            = this.storageBlobServiceClient.listBlobFlatSegmentWithRestResponse(pageId,
             containerName,
             prefix,
             maxResults,
@@ -118,6 +131,19 @@ public class StorageBlobClient {
             timeout,
             requestId,
             cancellationToken);
+        final List<BlobItem> list;
+        if (result.getValue().getSegment() != null
+            && result.getValue().getSegment().getBlobItems() != null) {
+            list = result.getValue().getSegment().getBlobItems();
+        } else {
+            list = new ArrayList<>(0);
+        }
+        BlobsPage blobsPage = new BlobsPage(list, pageId, result.getValue().getNextMarker());
+
+        return new Response<>(null,
+            result.getStatusCode(),
+            result.getHeaders(),
+            blobsPage);
     }
 
     /**
@@ -455,20 +481,20 @@ public class StorageBlobClient {
      * @param cancellationToken The token to request cancellation.
      * @return A response object containing the details of the delete operation.
      */
-    BlobDeleteResponse deleteWithResponse(String containerName,
-                                          String blobName,
-                                          String snapshot,
-                                          Integer timeout,
-                                          String version,
-                                          String leaseId,
-                                          DeleteSnapshotsOptionType deleteSnapshots,
-                                          OffsetDateTime ifModifiedSince,
-                                          OffsetDateTime ifUnmodifiedSince,
-                                          String ifMatch,
-                                          String ifNoneMatch,
-                                          String requestId,
-                                          CancellationToken cancellationToken) {
-        return storageBlobServiceClient.deleteWithResponse(containerName,
+    BlobDeleteResponse deleteWithRestResponse(String containerName,
+                                              String blobName,
+                                              String snapshot,
+                                              Integer timeout,
+                                              String version,
+                                              String leaseId,
+                                              DeleteSnapshotsOptionType deleteSnapshots,
+                                              OffsetDateTime ifModifiedSince,
+                                              OffsetDateTime ifUnmodifiedSince,
+                                              String ifMatch,
+                                              String ifNoneMatch,
+                                              String requestId,
+                                              CancellationToken cancellationToken) {
+        return storageBlobServiceClient.deleteWithRestResponse(containerName,
             blobName,
             snapshot,
             timeout,

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobServiceImpl.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobServiceImpl.java
@@ -5,7 +5,7 @@ package com.azure.android.storage.blob;
 
 import androidx.annotation.NonNull;
 
-import com.azure.android.core.http.Callback;
+import com.azure.android.core.http.CallbackWithHeader;
 import com.azure.android.core.http.ServiceClient;
 import com.azure.android.core.internal.util.CancellationTokenImpl;
 import com.azure.android.core.internal.util.serializer.SerializerAdapter;
@@ -20,7 +20,6 @@ import com.azure.android.storage.blob.models.BlobDownloadHeaders;
 import com.azure.android.storage.blob.models.BlobGetPropertiesHeaders;
 import com.azure.android.storage.blob.models.BlobGetPropertiesResponse;
 import com.azure.android.storage.blob.models.BlobHttpHeaders;
-import com.azure.android.storage.blob.models.BlobItem;
 import com.azure.android.storage.blob.models.BlobRequestConditions;
 import com.azure.android.storage.blob.models.BlobStorageException;
 import com.azure.android.storage.blob.models.BlobDeleteResponse;
@@ -30,7 +29,7 @@ import com.azure.android.storage.blob.models.BlockBlobStageBlockHeaders;
 import com.azure.android.storage.blob.models.BlockBlobsCommitBlockListResponse;
 import com.azure.android.storage.blob.models.BlockBlobsStageBlockResponse;
 import com.azure.android.storage.blob.models.BlockLookupList;
-import com.azure.android.storage.blob.models.ContainerListBlobFlatSegmentHeaders;
+import com.azure.android.storage.blob.models.ListBlobFlatSegmentHeaders;
 import com.azure.android.storage.blob.models.ContainersListBlobFlatSegmentResponse;
 import com.azure.android.storage.blob.models.CpkInfo;
 import com.azure.android.storage.blob.models.DeleteSnapshotsOptionType;
@@ -43,7 +42,6 @@ import org.threeten.bp.OffsetDateTime;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -75,12 +73,12 @@ final class StorageBlobServiceImpl {
         this.serializerAdapter = serviceClient.getSerializerAdapter();
     }
 
-    List<BlobItem> getBlobsInPage(String pageId,
-                                  String containerName,
-                                  ListBlobsOptions options) {
+    ListBlobsFlatSegmentResponse listBlobFlatSegment(String pageId,
+                                                     String containerName,
+                                                     ListBlobsOptions options) {
         options = options == null ? new ListBlobsOptions() : options;
 
-        ContainersListBlobFlatSegmentResponse response = this.getBlobsInPageWithRestResponse(pageId,
+        ContainersListBlobFlatSegmentResponse response = this.listBlobFlatSegmentWithRestResponse(pageId,
             containerName,
             options.getPrefix(),
             options.getMaxResultsPerPage(),
@@ -89,18 +87,16 @@ final class StorageBlobServiceImpl {
             null,
             CancellationToken.NONE);
 
-        return response.getValue().getSegment() == null
-            ? new ArrayList<>(0)
-            : response.getValue().getSegment().getBlobItems();
+        return response.getValue();
     }
 
-    void getBlobsInPage(String pageId,
-                        String containerName,
-                        ListBlobsOptions options,
-                        Callback<List<BlobItem>> callback) {
+    void listBlobFlatSegment(String pageId,
+                             String containerName,
+                             ListBlobsOptions options,
+                             CallbackWithHeader<ListBlobsFlatSegmentResponse, ListBlobFlatSegmentHeaders> callback) {
         options = options == null ? new ListBlobsOptions() : options;
 
-        this.getBlobsInPageWithRestResponse(pageId,
+        this.listBlobFlatSegment(pageId,
             containerName,
             options.getPrefix(),
             options.getMaxResultsPerPage(),
@@ -108,32 +104,18 @@ final class StorageBlobServiceImpl {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<ContainersListBlobFlatSegmentResponse>() {
-                @Override
-                public void onResponse(ContainersListBlobFlatSegmentResponse response) {
-                    List<BlobItem> value = response.getValue().getSegment() == null
-                        ? new ArrayList<>(0)
-                        : response.getValue().getSegment().getBlobItems();
-
-                    callback.onResponse(value);
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    callback.onFailure(t);
-                }
-            });
+            callback);
     }
 
-    ContainersListBlobFlatSegmentResponse getBlobsInPageWithRestResponse(String pageId,
-                                                                         String containerName,
-                                                                         String prefix,
-                                                                         Integer maxResults,
-                                                                         List<ListBlobsIncludeItem> include,
-                                                                         Integer timeout,
-                                                                         String requestId,
-                                                                         CancellationToken cancellationToken) {
-        return this.getBlobsInPageWithRestResponseIntern(pageId, containerName,
+    ContainersListBlobFlatSegmentResponse listBlobFlatSegmentWithRestResponse(String pageId,
+                                                                              String containerName,
+                                                                              String prefix,
+                                                                              Integer maxResults,
+                                                                              List<ListBlobsIncludeItem> include,
+                                                                              Integer timeout,
+                                                                              String requestId,
+                                                                              CancellationToken cancellationToken) {
+        return this.listBlobFlatSegmentWithRestResponseIntern(pageId, containerName,
             prefix,
             maxResults,
             include,
@@ -143,16 +125,16 @@ final class StorageBlobServiceImpl {
             null);
     }
 
-    void getBlobsInPageWithRestResponse(String pageId,
-                                        String containerName,
-                                        String prefix,
-                                        Integer maxResults,
-                                        List<ListBlobsIncludeItem> include,
-                                        Integer timeout,
-                                        String requestId,
-                                        CancellationToken cancellationToken,
-                                        Callback<ContainersListBlobFlatSegmentResponse> callback) {
-        this.getBlobsInPageWithRestResponseIntern(pageId,
+    void listBlobFlatSegment(String pageId,
+                             String containerName,
+                             String prefix,
+                             Integer maxResults,
+                             List<ListBlobsIncludeItem> include,
+                             Integer timeout,
+                             String requestId,
+                             CancellationToken cancellationToken,
+                             CallbackWithHeader<ListBlobsFlatSegmentResponse, ListBlobFlatSegmentHeaders> callback) {
+        this.listBlobFlatSegmentWithRestResponseIntern(pageId,
             containerName,
             prefix,
             maxResults,
@@ -194,8 +176,8 @@ final class StorageBlobServiceImpl {
      */
     void getBlobProperties(String containerName,
                            String blobName,
-                           Callback<BlobGetPropertiesHeaders> callback) {
-        getBlobPropertiesWithRestResponse(containerName,
+                           CallbackWithHeader<Void, BlobGetPropertiesHeaders> callback) {
+        getBlobPropertiesWithRestResponseIntern(containerName,
             blobName,
             null,
             null,
@@ -204,17 +186,7 @@ final class StorageBlobServiceImpl {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlobGetPropertiesResponse>() {
-                @Override
-                public void onResponse(BlobGetPropertiesResponse response) {
-                    callback.onResponse(response.getDeserializedHeaders());
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    callback.onFailure(t);
-                }
-            });
+            callback);
     }
 
     /**
@@ -266,16 +238,16 @@ final class StorageBlobServiceImpl {
      * @param cpkInfo       Additional parameters for the operation.
      * @param callback      Callback that receives the response.
      */
-    void getBlobPropertiesWithRestResponse(String containerName,
-                                           String blobName,
-                                           String snapshot,
-                                           Integer timeout,
-                                           String version,
-                                           String leaseId,
-                                           String requestId,
-                                           CpkInfo cpkInfo,
-                                           CancellationToken cancellationToken,
-                                           Callback<BlobGetPropertiesResponse> callback) {
+    void getBlobProperties(String containerName,
+                           String blobName,
+                           String snapshot,
+                           Integer timeout,
+                           String version,
+                           String leaseId,
+                           String requestId,
+                           CpkInfo cpkInfo,
+                           CancellationToken cancellationToken,
+                           CallbackWithHeader<Void, BlobGetPropertiesHeaders> callback) {
         this.getBlobPropertiesWithRestResponseIntern(containerName,
             blobName,
             snapshot,
@@ -324,8 +296,8 @@ final class StorageBlobServiceImpl {
      */
     void download(String containerName,
                   String blobName,
-                  Callback<ResponseBody> callback) {
-        downloadWithRestResponse(containerName,
+                  CallbackWithHeader<ResponseBody, BlobDownloadHeaders> callback) {
+        rawDownload(containerName,
             blobName,
             null,
             null,
@@ -341,17 +313,7 @@ final class StorageBlobServiceImpl {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlobDownloadResponse>() {
-                @Override
-                public void onResponse(BlobDownloadResponse response) {
-                    callback.onResponse(response.getValue());
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    callback.onFailure(t);
-                }
-            });
+            callback);
     }
 
     /**
@@ -445,23 +407,23 @@ final class StorageBlobServiceImpl {
      * @param cpkInfo              Additional parameters for the operation.
      * @param callback             Callback that receives the response.
      */
-    void downloadWithRestResponse(String containerName,
-                                  String blobName,
-                                  String snapshot,
-                                  Integer timeout,
-                                  String range,
-                                  String leaseId,
-                                  Boolean rangeGetContentMD5,
-                                  Boolean rangeGetContentCRC64,
-                                  OffsetDateTime ifModifiedSince,
-                                  OffsetDateTime ifUnmodifiedSince,
-                                  String ifMatch,
-                                  String ifNoneMatch,
-                                  String version,
-                                  String requestId,
-                                  CpkInfo cpkInfo,
-                                  CancellationToken cancellationToken,
-                                  Callback<BlobDownloadResponse> callback) {
+    void rawDownload(String containerName,
+                     String blobName,
+                     String snapshot,
+                     Integer timeout,
+                     String range,
+                     String leaseId,
+                     Boolean rangeGetContentMD5,
+                     Boolean rangeGetContentCRC64,
+                     OffsetDateTime ifModifiedSince,
+                     OffsetDateTime ifUnmodifiedSince,
+                     String ifMatch,
+                     String ifNoneMatch,
+                     String version,
+                     String requestId,
+                     CpkInfo cpkInfo,
+                     CancellationToken cancellationToken,
+                     CallbackWithHeader<ResponseBody, BlobDownloadHeaders> callback) {
         this.downloadWithRestResponseIntern(containerName,
             blobName,
             snapshot,
@@ -504,8 +466,8 @@ final class StorageBlobServiceImpl {
                     String base64BlockId,
                     byte[] blockContent,
                     byte[] contentMd5,
-                    Callback<Void> callback) {
-        this.stageBlockWithRestResponse(containerName,
+                    CallbackWithHeader<Void, BlockBlobStageBlockHeaders> callback) {
+        this.stageBlock(containerName,
             blobName,
             base64BlockId,
             blockContent,
@@ -516,17 +478,7 @@ final class StorageBlobServiceImpl {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlockBlobsStageBlockResponse>() {
-                @Override
-                public void onResponse(BlockBlobsStageBlockResponse response) {
-                    callback.onResponse(response.getValue());
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    callback.onFailure(t);
-                }
-            });
+            callback);
     }
 
     BlockBlobsStageBlockResponse stageBlockWithRestResponse(String containerName,
@@ -554,18 +506,18 @@ final class StorageBlobServiceImpl {
             null);
     }
 
-    void stageBlockWithRestResponse(String containerName,
-                                    String blobName,
-                                    String base64BlockId,
-                                    byte[] blockContent,
-                                    byte[] transactionalContentMD5,
-                                    byte[] transactionalContentCrc64,
-                                    Integer timeout,
-                                    String leaseId,
-                                    String requestId,
-                                    CpkInfo cpkInfo,
-                                    CancellationToken cancellationToken,
-                                    Callback<BlockBlobsStageBlockResponse> callback) {
+    void stageBlock(String containerName,
+                    String blobName,
+                    String base64BlockId,
+                    byte[] blockContent,
+                    byte[] transactionalContentMD5,
+                    byte[] transactionalContentCrc64,
+                    Integer timeout,
+                    String leaseId,
+                    String requestId,
+                    CpkInfo cpkInfo,
+                    CancellationToken cancellationToken,
+                    CallbackWithHeader<Void, BlockBlobStageBlockHeaders> callback) {
         this.stageBlockWithRestResponseIntern(containerName,
             blobName,
             base64BlockId,
@@ -611,14 +563,14 @@ final class StorageBlobServiceImpl {
                          String blobName,
                          List<String> base64BlockIds,
                          boolean overwrite,
-                         Callback<BlockBlobItem> callBack) {
+                         CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders> callback) {
         BlobRequestConditions requestConditions = null;
 
         if (!overwrite) {
             requestConditions = new BlobRequestConditions().setIfNoneMatch("*");
         }
 
-        this.commitBlockListWithRestResponse(containerName,
+        this.commitBlockList(containerName,
             blobName,
             base64BlockIds,
             null,
@@ -631,17 +583,7 @@ final class StorageBlobServiceImpl {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlockBlobsCommitBlockListResponse>() {
-                @Override
-                public void onResponse(BlockBlobsCommitBlockListResponse response) {
-                    callBack.onResponse(response.getBlockBlobItem());
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    callBack.onFailure(t);
-                }
-            });
+            callback);
     }
 
     BlockBlobsCommitBlockListResponse commitBlockListWithRestResponse(String containerName,
@@ -673,20 +615,20 @@ final class StorageBlobServiceImpl {
             null);
     }
 
-    void commitBlockListWithRestResponse(String containerName,
-                                         String blobName,
-                                         List<String> base64BlockIds,
-                                         byte[] transactionalContentMD5,
-                                         byte[] transactionalContentCrc64,
-                                         Integer timeout,
-                                         BlobHttpHeaders blobHttpHeaders,
-                                         Map<String, String> metadata,
-                                         BlobRequestConditions requestConditions,
-                                         String requestId,
-                                         CpkInfo cpkInfo,
-                                         AccessTier tier,
-                                         CancellationToken cancellationToken,
-                                         Callback<BlockBlobsCommitBlockListResponse> callback) {
+    void commitBlockList(String containerName,
+                         String blobName,
+                         List<String> base64BlockIds,
+                         byte[] transactionalContentMD5,
+                         byte[] transactionalContentCrc64,
+                         Integer timeout,
+                         BlobHttpHeaders blobHttpHeaders,
+                         Map<String, String> metadata,
+                         BlobRequestConditions requestConditions,
+                         String requestId,
+                         CpkInfo cpkInfo,
+                         AccessTier tier,
+                         CancellationToken cancellationToken,
+                         CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders> callback) {
         this.commitBlockListWithRestResponseIntern(containerName,
             blobName,
             base64BlockIds,
@@ -711,7 +653,7 @@ final class StorageBlobServiceImpl {
      */
     Void delete(String containerName,
                 String blobName) {
-        return deleteWithResponse(containerName,
+        return deleteWithRestResponse(containerName,
             blobName,
             null,
             null,
@@ -736,8 +678,8 @@ final class StorageBlobServiceImpl {
      */
     void delete(String containerName,
                 String blobName,
-                Callback<Void> callback) {
-        deleteWithResponse(containerName,
+                CallbackWithHeader<Void, BlobDeleteHeaders> callback) {
+        delete(containerName,
             blobName,
             null,
             null,
@@ -750,17 +692,7 @@ final class StorageBlobServiceImpl {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlobDeleteResponse>() {
-                @Override
-                public void onResponse(BlobDeleteResponse response) {
-                    callback.onResponse(response.getValue());
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                    callback.onFailure(t);
-                }
-            });
+            callback);
     }
 
     /**
@@ -802,19 +734,19 @@ final class StorageBlobServiceImpl {
      *                          recorded in the analytics logs when storage analytics logging is enabled.
      * @return A response object containing the details of the delete operation.
      */
-    BlobDeleteResponse deleteWithResponse(String containerName,
-                                          String blobName,
-                                          String snapshot,
-                                          Integer timeout,
-                                          String version,
-                                          String leaseId,
-                                          DeleteSnapshotsOptionType deleteSnapshots,
-                                          OffsetDateTime ifModifiedSince,
-                                          OffsetDateTime ifUnmodifiedSince,
-                                          String ifMatch,
-                                          String ifNoneMatch,
-                                          String requestId,
-                                          CancellationToken cancellationToken) {
+    BlobDeleteResponse deleteWithRestResponse(String containerName,
+                                              String blobName,
+                                              String snapshot,
+                                              Integer timeout,
+                                              String version,
+                                              String leaseId,
+                                              DeleteSnapshotsOptionType deleteSnapshots,
+                                              OffsetDateTime ifModifiedSince,
+                                              OffsetDateTime ifUnmodifiedSince,
+                                              String ifMatch,
+                                              String ifNoneMatch,
+                                              String requestId,
+                                              CancellationToken cancellationToken) {
         return deleteWithRestResponseIntern(containerName,
             blobName,
             snapshot,
@@ -871,20 +803,20 @@ final class StorageBlobServiceImpl {
      * @param callback          Callback that receives the response.
      * @return A handle to the service call.
      */
-    void deleteWithResponse(String containerName,
-                            String blobName,
-                            String snapshot,
-                            Integer timeout,
-                            String version,
-                            String leaseId,
-                            DeleteSnapshotsOptionType deleteSnapshots,
-                            OffsetDateTime ifModifiedSince,
-                            OffsetDateTime ifUnmodifiedSince,
-                            String ifMatch,
-                            String ifNoneMatch,
-                            String requestId,
-                            CancellationToken cancellationToken,
-                            Callback<BlobDeleteResponse> callback) {
+    void delete(String containerName,
+                String blobName,
+                String snapshot,
+                Integer timeout,
+                String version,
+                String leaseId,
+                DeleteSnapshotsOptionType deleteSnapshots,
+                OffsetDateTime ifModifiedSince,
+                OffsetDateTime ifUnmodifiedSince,
+                String ifMatch,
+                String ifNoneMatch,
+                String requestId,
+                CancellationToken cancellationToken,
+                CallbackWithHeader<Void, BlobDeleteHeaders> callback) {
         deleteWithRestResponseIntern(containerName,
             blobName,
             snapshot,
@@ -901,15 +833,15 @@ final class StorageBlobServiceImpl {
             callback);
     }
 
-    private ContainersListBlobFlatSegmentResponse getBlobsInPageWithRestResponseIntern(String pageId,
-                                                                                       String containerName,
-                                                                                       String prefix,
-                                                                                       Integer maxResults,
-                                                                                       List<ListBlobsIncludeItem> include,
-                                                                                       Integer timeout,
-                                                                                       String requestId,
-                                                                                       CancellationToken cancellationToken,
-                                                                                       Callback<ContainersListBlobFlatSegmentResponse> callback) {
+    private ContainersListBlobFlatSegmentResponse listBlobFlatSegmentWithRestResponseIntern(String pageId,
+                                                                                            String containerName,
+                                                                                            String prefix,
+                                                                                            Integer maxResults,
+                                                                                            List<ListBlobsIncludeItem> include,
+                                                                                            Integer timeout,
+                                                                                            String requestId,
+                                                                                            CancellationToken cancellationToken,
+                                                                                            CallbackWithHeader<ListBlobsFlatSegmentResponse, ListBlobFlatSegmentHeaders> callback) {
         cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
         final String resType = "container";
         final String comp = "list";
@@ -937,28 +869,26 @@ final class StorageBlobServiceImpl {
                         if (response.code() == 200) {
                             ListBlobsFlatSegmentResponse typedContent = deserializeContent(response.body(),
                                 ListBlobsFlatSegmentResponse.class);
-                            ContainerListBlobFlatSegmentHeaders typedHeader = deserializeHeaders(response.headers(),
-                                ContainerListBlobFlatSegmentHeaders.class);
-                            callback.onResponse(new ContainersListBlobFlatSegmentResponse(response.raw().request(),
-                                response.code(),
-                                response.headers(),
-                                typedContent,
-                                typedHeader));
+                            ListBlobFlatSegmentHeaders typedHeader = deserializeHeaders(response.headers(),
+                                ListBlobFlatSegmentHeaders.class);
+                            callback.onSuccess(typedContent,
+                                typedHeader,
+                                response.raw());
                         } else {
                             String strContent = readAsString(response.body());
 
-                            callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                            callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                         }
                     } else {
                         String strContent = readAsString(response.errorBody());
 
-                        callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                        callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                     }
                 }
 
                 @Override
                 public void onFailure(Call<ResponseBody> call, Throwable t) {
-                    callback.onFailure(t);
+                    callback.onFailure(t, null);
                 }
             });
 
@@ -970,8 +900,8 @@ final class StorageBlobServiceImpl {
                 if (response.code() == 200) {
                     ListBlobsFlatSegmentResponse typedContent = deserializeContent(response.body(),
                         ListBlobsFlatSegmentResponse.class);
-                    ContainerListBlobFlatSegmentHeaders typedHeader = deserializeHeaders(response.headers(),
-                        ContainerListBlobFlatSegmentHeaders.class);
+                    ListBlobFlatSegmentHeaders typedHeader = deserializeHeaders(response.headers(),
+                        ListBlobFlatSegmentHeaders.class);
 
                     ContainersListBlobFlatSegmentResponse result =
                         new ContainersListBlobFlatSegmentResponse(response.raw().request(),
@@ -1003,7 +933,7 @@ final class StorageBlobServiceImpl {
                                                                               String requestId,
                                                                               CpkInfo cpkInfo,
                                                                               CancellationToken cancellationToken,
-                                                                              Callback<BlobGetPropertiesResponse> callback) {
+                                                                              CallbackWithHeader<Void, BlobGetPropertiesHeaders> callback) {
         cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
         String encryptionKey = null;
         String encryptionKeySha256 = null;
@@ -1039,24 +969,20 @@ final class StorageBlobServiceImpl {
                             BlobGetPropertiesHeaders typedHeaders = deserializeHeaders(response.headers(),
                                 BlobGetPropertiesHeaders.class);
 
-                            callback.onResponse(new BlobGetPropertiesResponse(response.raw().request(),
-                                response.code(),
-                                response.headers(),
-                                null,
-                                typedHeaders));
+                            callback.onSuccess(null, typedHeaders, response.raw());
                         } else {
-                            callback.onFailure(new BlobStorageException(null, response.raw()));
+                            callback.onFailure(new BlobStorageException(null, response.raw()), response.raw());
                         }
                     } else {
                         String strContent = readAsString(response.errorBody());
 
-                        callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                        callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                     }
                 }
 
                 @Override
                 public void onFailure(@NonNull Call<Void> call, @NonNull Throwable t) {
-                    callback.onFailure(t);
+                    callback.onFailure(t, null);
                 }
             });
 
@@ -1103,7 +1029,7 @@ final class StorageBlobServiceImpl {
                                                                 String requestId,
                                                                 CpkInfo cpkInfo,
                                                                 CancellationToken cancellationToken,
-                                                                Callback<BlobDownloadResponse> callback) {
+                                                                CallbackWithHeader<ResponseBody, BlobDownloadHeaders> callback) {
         cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
         String encryptionKey = null;
         String encryptionKeySha256 = null;
@@ -1151,26 +1077,22 @@ final class StorageBlobServiceImpl {
                             BlobDownloadHeaders typedHeaders = deserializeHeaders(response.headers(),
                                 BlobDownloadHeaders.class);
 
-                            callback.onResponse(new BlobDownloadResponse(response.raw().request(),
-                                response.code(),
-                                response.headers(),
-                                response.body(),
-                                typedHeaders));
+                            callback.onSuccess(response.body(),
+                                typedHeaders,
+                                response.raw());
                         } else {
                             String strContent = readAsString(response.body());
-
-                            callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                            callback.onFailure(new BlobStorageException(strContent, response.raw()),response.raw());
                         }
                     } else {
                         String strContent = readAsString(response.errorBody());
-
-                        callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                        callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                     }
                 }
 
                 @Override
                 public void onFailure(@NonNull Call<ResponseBody> call, @NonNull Throwable t) {
-                    callback.onFailure(t);
+                    callback.onFailure(t, null);
                 }
             });
 
@@ -1213,7 +1135,7 @@ final class StorageBlobServiceImpl {
                                                                           String requestId,
                                                                           CpkInfo cpkInfo,
                                                                           CancellationToken cancellationToken,
-                                                                          Callback<BlockBlobsStageBlockResponse> callback) {
+                                                                          CallbackWithHeader<Void, BlockBlobStageBlockHeaders> callback) {
         cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
         String encryptionKey = null;
         String encryptionKeySha256 = null;
@@ -1259,26 +1181,22 @@ final class StorageBlobServiceImpl {
                         if (response.code() == 201) {
                             BlockBlobStageBlockHeaders typedHeader = deserializeHeaders(response.headers(),
                                 BlockBlobStageBlockHeaders.class);
-                            callback.onResponse(new BlockBlobsStageBlockResponse(response.raw().request(),
-                                response.code(),
-                                response.headers(),
-                                null,
-                                typedHeader));
+                            callback.onSuccess(null, typedHeader, response.raw());
                         } else {
                             String strContent = readAsString(response.body());
 
-                            callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                            callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                         }
                     } else {
                         String strContent = readAsString(response.errorBody());
 
-                        callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                        callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                     }
                 }
 
                 @Override
                 public void onFailure(Call<ResponseBody> call, Throwable t) {
-                    callback.onFailure(t);
+                    callback.onFailure(t, null);
                 }
             });
             return null;
@@ -1322,7 +1240,7 @@ final class StorageBlobServiceImpl {
                                                                                     CpkInfo cpkInfo,
                                                                                     AccessTier tier,
                                                                                     CancellationToken cancellationToken,
-                                                                                    Callback<BlockBlobsCommitBlockListResponse> callback) {
+                                                                                    CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders> callback) {
         cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
         requestConditions = requestConditions == null ? new BlobRequestConditions() : requestConditions;
         String leaseId = requestConditions.getLeaseId();
@@ -1401,7 +1319,7 @@ final class StorageBlobServiceImpl {
                 serializerAdapter.serialize(blockLookupList, SerializerFormat.XML));
         } catch (IOException ioe) {
             if (callback != null) {
-                callback.onFailure(ioe);
+                callback.onFailure(ioe, null);
 
                 return null;
             } else {
@@ -1448,26 +1366,26 @@ final class StorageBlobServiceImpl {
                             BlockBlobCommitBlockListHeaders typedHeader =
                                 deserializeHeaders(response.headers(), BlockBlobCommitBlockListHeaders.class);
 
-                            callback.onResponse(new BlockBlobsCommitBlockListResponse(response.raw().request(),
-                                response.code(),
-                                response.headers(),
-                                null,
-                                typedHeader));
+                            callback.onSuccess(new BlockBlobItem(typedHeader.getETag(),
+                                    typedHeader.getLastModified(),
+                                    typedHeader.getContentMD5(),
+                                    typedHeader.isServerEncrypted(),
+                                    typedHeader.getEncryptionKeySha256()),
+                                typedHeader, response.raw());
                         } else {
                             String strContent = readAsString(response.body());
 
-                            callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                            callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                         }
                     } else {
                         String strContent = readAsString(response.errorBody());
 
-                        callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                        callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                     }
                 }
-
                 @Override
                 public void onFailure(Call<ResponseBody> call, Throwable t) {
-                    callback.onFailure(t);
+                    callback.onFailure(t, null);
                 }
             });
             return null;
@@ -1513,7 +1431,7 @@ final class StorageBlobServiceImpl {
                                                             String ifNoneMatch,
                                                             String requestId,
                                                             CancellationToken cancellationToken,
-                                                            Callback<BlobDeleteResponse> callback) {
+                                                            CallbackWithHeader<Void, BlobDeleteHeaders> callback) {
         cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
         DateTimeRfc1123 ifModifiedSinceConverted = ifModifiedSince == null ? null :
             new DateTimeRfc1123(ifModifiedSince);
@@ -1546,26 +1464,22 @@ final class StorageBlobServiceImpl {
                             BlobDeleteHeaders typedHeaders = deserializeHeaders(response.headers(),
                                 BlobDeleteHeaders.class);
 
-                            callback.onResponse(new BlobDeleteResponse(response.raw().request(),
-                                response.code(),
-                                response.headers(),
-                                null,
-                                typedHeaders));
+                            callback.onSuccess(null, typedHeaders, response.raw());
                         } else {
                             String strContent = readAsString(response.body());
 
-                            callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                            callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                         }
                     } else {
                         String strContent = readAsString(response.errorBody());
 
-                        callback.onFailure(new BlobStorageException(strContent, response.raw()));
+                        callback.onFailure(new BlobStorageException(strContent, response.raw()), response.raw());
                     }
                 }
 
                 @Override
                 public void onFailure(@NonNull Call<ResponseBody> call, @NonNull Throwable t) {
-                    callback.onFailure(t);
+                    callback.onFailure(t, null);
                 }
             });
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/models/BlobsPage.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/models/BlobsPage.java
@@ -1,0 +1,28 @@
+package com.azure.android.storage.blob.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlobsPage {
+    private final List<BlobItem> items;
+    private final String pageId;
+    private final String nextPageId;
+
+    public BlobsPage(List<BlobItem> items, String pageId, String nextPageId) {
+        this.items = items == null ? new ArrayList<>() : items;
+        this.pageId = pageId;
+        this.nextPageId = nextPageId;
+    }
+
+    public List<BlobItem>  getItems() {
+        return this.items;
+    }
+
+    public String getPageId() {
+        return this.pageId;
+    }
+
+    public String getNextPageId() {
+        return this.nextPageId;
+    }
+}

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/models/ContainersListBlobFlatSegmentResponse.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/models/ContainersListBlobFlatSegmentResponse.java
@@ -9,7 +9,7 @@ import com.azure.android.core.http.ResponseBase;
  * Contains all response data for the listBlobFlatSegment operation.
  */
 public final class ContainersListBlobFlatSegmentResponse
-        extends ResponseBase<ContainerListBlobFlatSegmentHeaders, ListBlobsFlatSegmentResponse> {
+        extends ResponseBase<ListBlobFlatSegmentHeaders, ListBlobsFlatSegmentResponse> {
 
     /**
      * Creates an instance of ContainersListBlobFlatSegmentResponse.
@@ -24,7 +24,7 @@ public final class ContainersListBlobFlatSegmentResponse
                                                  int statusCode,
                                                  okhttp3.Headers rawHeaders,
                                                  ListBlobsFlatSegmentResponse value,
-                                                 ContainerListBlobFlatSegmentHeaders headers) {
+                                                 ListBlobFlatSegmentHeaders headers) {
         super(request, statusCode, rawHeaders, value, headers);
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/models/ListBlobFlatSegmentHeaders.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/models/ListBlobFlatSegmentHeaders.java
@@ -13,7 +13,7 @@ import org.threeten.bp.OffsetDateTime;
  * Defines headers for ListBlobFlatSegment operation.
  */
 @JacksonXmlRootElement(localName = "Container-ListBlobFlatSegment-Headers")
-public final class ContainerListBlobFlatSegmentHeaders {
+public final class ListBlobFlatSegmentHeaders {
     /*
      * The media type of the body of the response. For List Blobs this is
      * 'application/xml'
@@ -73,7 +73,7 @@ public final class ContainerListBlobFlatSegmentHeaders {
      * @param contentType the contentType value to set.
      * @return the ContainerListBlobFlatSegmentHeaders object itself.
      */
-    public ContainerListBlobFlatSegmentHeaders setContentType(String contentType) {
+    public ListBlobFlatSegmentHeaders setContentType(String contentType) {
         this.contentType = contentType;
         return this;
     }
@@ -97,7 +97,7 @@ public final class ContainerListBlobFlatSegmentHeaders {
      * @param clientRequestId the clientRequestId value to set.
      * @return the ContainerListBlobFlatSegmentHeaders object itself.
      */
-    public ContainerListBlobFlatSegmentHeaders setClientRequestId(String clientRequestId) {
+    public ListBlobFlatSegmentHeaders setClientRequestId(String clientRequestId) {
         this.clientRequestId = clientRequestId;
         return this;
     }
@@ -119,7 +119,7 @@ public final class ContainerListBlobFlatSegmentHeaders {
      * @param requestId the requestId value to set.
      * @return the ContainerListBlobFlatSegmentHeaders object itself.
      */
-    public ContainerListBlobFlatSegmentHeaders setRequestId(String requestId) {
+    public ListBlobFlatSegmentHeaders setRequestId(String requestId) {
         this.requestId = requestId;
         return this;
     }
@@ -143,7 +143,7 @@ public final class ContainerListBlobFlatSegmentHeaders {
      * @param version the version value to set.
      * @return the ContainerListBlobFlatSegmentHeaders object itself.
      */
-    public ContainerListBlobFlatSegmentHeaders setVersion(String version) {
+    public ListBlobFlatSegmentHeaders setVersion(String version) {
         this.version = version;
         return this;
     }
@@ -168,7 +168,7 @@ public final class ContainerListBlobFlatSegmentHeaders {
      * @param dateProperty the dateProperty value to set.
      * @return the ContainerListBlobFlatSegmentHeaders object itself.
      */
-    public ContainerListBlobFlatSegmentHeaders setDateProperty(OffsetDateTime dateProperty) {
+    public ListBlobFlatSegmentHeaders setDateProperty(OffsetDateTime dateProperty) {
         if (dateProperty == null) {
             this.dateProperty = null;
         } else {
@@ -192,7 +192,7 @@ public final class ContainerListBlobFlatSegmentHeaders {
      * @param errorCode the errorCode value to set.
      * @return the ContainerListBlobFlatSegmentHeaders object itself.
      */
-    public ContainerListBlobFlatSegmentHeaders setErrorCode(String errorCode) {
+    public ListBlobFlatSegmentHeaders setErrorCode(String errorCode) {
         this.errorCode = errorCode;
         return this;
     }

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/transfer/TransferClient.java
@@ -21,11 +21,14 @@ import androidx.work.WorkManager;
 import androidx.work.impl.WorkManagerImpl;
 
 import com.azure.android.core.http.Callback;
+import com.azure.android.core.http.CallbackWithHeader;
 import com.azure.android.storage.blob.StorageBlobAsyncClient;
 import com.azure.android.storage.blob.models.BlobGetPropertiesHeaders;
 
 import java.util.List;
 import java.util.concurrent.Executors;
+
+import okhttp3.Response;
 
 /**
  * A type that exposes blob transfer APIs.
@@ -178,10 +181,10 @@ public final class TransferClient {
                     return;
                 }
                 blobClient.getBlobProperties(downloadRequest.getContainerName(), downloadRequest.getBlobName(),
-                    new Callback<BlobGetPropertiesHeaders>() {
+                    new CallbackWithHeader<Void, BlobGetPropertiesHeaders>() {
                         @Override
-                        public void onResponse(BlobGetPropertiesHeaders response) {
-                            final long blobSize = response.getContentLength();
+                        public void onSuccess(Void result, BlobGetPropertiesHeaders header, Response response) {
+                            final long blobSize = header.getContentLength();
                             BlobDownloadEntity blob = new BlobDownloadEntity(downloadRequest.getStorageClientId(),
                                 downloadRequest.getContainerName(),
                                 downloadRequest.getBlobName(),
@@ -215,7 +218,7 @@ public final class TransferClient {
                         }
 
                         @Override
-                        public void onFailure(Throwable throwable) {
+                        public void onFailure(Throwable throwable, Response response) {
                             transferOpResultLiveData
                                 .postValue(TransferOperationResult.error(TransferOperationResult.Operation.UPLOAD_DOWNLOAD, throwable));
                         }

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/android/storage/blob/StorageBlobClientTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/android/storage/blob/StorageBlobClientTest.java
@@ -1,18 +1,23 @@
 package com.azure.android.storage.blob;
 
 import com.azure.android.core.http.Callback;
+import com.azure.android.core.http.CallbackWithHeader;
 import com.azure.android.core.http.ServiceClient;
 import com.azure.android.core.internal.util.serializer.SerializerFormat;
 import com.azure.android.core.util.CancellationToken;
+import com.azure.android.storage.blob.models.BlobDeleteHeaders;
 import com.azure.android.storage.blob.models.BlobDeleteResponse;
+import com.azure.android.storage.blob.models.BlobDownloadHeaders;
 import com.azure.android.storage.blob.models.BlobDownloadResponse;
 import com.azure.android.storage.blob.models.BlobGetPropertiesHeaders;
 import com.azure.android.storage.blob.models.BlobGetPropertiesResponse;
 import com.azure.android.storage.blob.models.BlobItem;
+import com.azure.android.storage.blob.models.BlobsPage;
+import com.azure.android.storage.blob.models.BlockBlobCommitBlockListHeaders;
 import com.azure.android.storage.blob.models.BlockBlobItem;
+import com.azure.android.storage.blob.models.BlockBlobStageBlockHeaders;
 import com.azure.android.storage.blob.models.BlockBlobsCommitBlockListResponse;
 import com.azure.android.storage.blob.models.BlockBlobsStageBlockResponse;
-import com.azure.android.storage.blob.models.ContainersListBlobFlatSegmentResponse;
 
 import org.junit.After;
 import org.junit.Test;
@@ -21,12 +26,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -85,14 +90,15 @@ public class StorageBlobClientTest {
 
         mockWebServer.enqueue(mockResponse);
 
-        List<BlobItem> blobItems = storageBlobClient.getBlobsInPage(null,
+        BlobsPage blobsPage = storageBlobClient.getBlobsInPage(null,
             "testContainer",
             null);
 
         // Then a list containing the details of the blobs will be returned by the service and converted to BlobItem
         // objects by the client.
-        assertNotEquals(0, blobItems.size());
-        assertEquals("test.jpg", blobItems.get(0).getName());
+        assertNotEquals(0, blobsPage.getItems()
+            .size());
+        assertEquals("test.jpg", blobsPage.getItems().get(0).getName());
     }
 
     @Test
@@ -113,23 +119,24 @@ public class StorageBlobClientTest {
         storageBlobAsyncClient.getBlobsInPage(null,
             "testContainer",
             null,
-            new Callback<List<BlobItem>>() {
+
+            new Callback<BlobsPage>() {
                 @Override
-                public void onResponse(List<BlobItem> response) {
+                public void onSuccess(BlobsPage result, Response response) {
                     try {
                         // Then a list containing the details of the blobs will be returned to the callback by the service
                         // and converted to BlobItem objects by the client.
-                        assertNotEquals(0, response.size());
-                        assertEquals("test.jpg", response.get(0).getName());
+                        assertNotEquals(0, result.getItems().size());
+                        assertEquals("test.jpg", result.getItems().get(0).getName());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -152,7 +159,7 @@ public class StorageBlobClientTest {
 
         mockWebServer.enqueue(mockResponse);
 
-        ContainersListBlobFlatSegmentResponse response =
+        com.azure.android.core.http.Response<BlobsPage> response =
             storageBlobClient.getBlobsInPageWithRestResponse(null,
                 "testContainer",
                 null,
@@ -164,9 +171,8 @@ public class StorageBlobClientTest {
 
         // Then the client will return an object that contains both the details of the REST response and a list
         // with the details of the blobs.
-        List<BlobItem> blobItems = response.getValue().getSegment() == null
-            ? new ArrayList<>(0)
-            : response.getValue().getSegment().getBlobItems();
+        BlobsPage blobsPage = response.getValue();
+        List<BlobItem> blobItems = blobsPage.getItems();
 
         assertEquals(200, response.getStatusCode());
         assertNotEquals(0, blobItems.size());
@@ -189,7 +195,7 @@ public class StorageBlobClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        storageBlobAsyncClient.getBlobsInPageWithRestResponse(null,
+        storageBlobAsyncClient.getBlobsInPage(null,
             "testContainer",
             null,
             null,
@@ -197,17 +203,15 @@ public class StorageBlobClientTest {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<ContainersListBlobFlatSegmentResponse>() {
+            new Callback<BlobsPage>() {
                 @Override
-                public void onResponse(ContainersListBlobFlatSegmentResponse response) {
+                public void onSuccess(BlobsPage result, Response response) {
                     try {
                         // Then the client will return an object that contains both the details of the REST response and
                         // a list with the details of the blobs to the callback.
-                        List<BlobItem> blobItems = response.getValue().getSegment() == null
-                            ? new ArrayList<>(0)
-                            : response.getValue().getSegment().getBlobItems();
+                        List<BlobItem> blobItems = result.getItems();
 
-                        assertEquals(200, response.getStatusCode());
+                        assertEquals(200, response.code());
                         assertNotEquals(0, blobItems.size());
                         assertEquals("test.jpg", blobItems.get(0).getName());
                     } finally {
@@ -216,9 +220,9 @@ public class StorageBlobClientTest {
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -261,21 +265,21 @@ public class StorageBlobClientTest {
 
         storageBlobAsyncClient.getBlobProperties("container",
             "blob",
-            new Callback<BlobGetPropertiesHeaders>() {
+            new CallbackWithHeader<Void, BlobGetPropertiesHeaders>() {
                 @Override
-                public void onResponse(BlobGetPropertiesHeaders response) {
+                public void onSuccess(Void result, BlobGetPropertiesHeaders header, Response response) {
                     try {
                         // Then an object with the blob properties will be returned by the client to the callback.
-                        assertEquals("application/text", response.getContentType());
+                        assertEquals("application/text", header.getContentType());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -326,7 +330,7 @@ public class StorageBlobClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        storageBlobAsyncClient.getBlobPropertiesWithRestResponse("container",
+        storageBlobAsyncClient.getBlobProperties("container",
             "blob",
             null,
             null,
@@ -335,22 +339,23 @@ public class StorageBlobClientTest {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlobGetPropertiesResponse>() {
+            new CallbackWithHeader<Void, BlobGetPropertiesHeaders>() {
+
                 @Override
-                public void onResponse(BlobGetPropertiesResponse response) {
+                public void onSuccess(Void result, BlobGetPropertiesHeaders header, Response response) {
                     try {
                         // Then the client will return an object that contains both the details of the REST response and
                         // an object with the blob properties to the callback.
-                        assertEquals("application/text", response.getDeserializedHeaders().getContentType());
+                        assertEquals("application/text", header.getContentType());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable error, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(error);
                     } finally {
                         latch.countDown();
                     }
@@ -393,23 +398,24 @@ public class StorageBlobClientTest {
 
         storageBlobAsyncClient.rawDownload("testContainer",
             "testBlob",
-            new Callback<ResponseBody>() {
+
+            new CallbackWithHeader<ResponseBody, BlobDownloadHeaders>() {
                 @Override
-                public void onResponse(ResponseBody response) {
+                public void onSuccess(ResponseBody result, BlobDownloadHeaders header, Response response) {
                     try {
                         // Then an object with the blob's contents will be returned by the client.
-                        assertEquals("testBody", response.string());
+                        assertEquals("testBody", result.string());
                     } catch (IOException e) {
-                        onFailure(e);
+                        onFailure(e, response);
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -463,7 +469,7 @@ public class StorageBlobClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        storageBlobAsyncClient.rawDownloadWithRestResponse("testContainer",
+        storageBlobAsyncClient.rawDownload("testContainer",
             "testBlob",
             null,
             null,
@@ -475,25 +481,25 @@ public class StorageBlobClientTest {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlobDownloadResponse>() {
+            new CallbackWithHeader<ResponseBody, BlobDownloadHeaders>() {
                 @Override
-                public void onResponse(BlobDownloadResponse response) {
+                public void onSuccess(ResponseBody result, BlobDownloadHeaders header, Response response) {
                     try {
                         // Then an object with the blob's contents will be returned by the client to the callback,
                         // including its properties and details from the REST response.
-                        assertEquals(200, response.getStatusCode());
-                        assertEquals("testBody", response.getValue().string());
+                        assertEquals(200, response.code());
+                        assertEquals("testBody", result.string());
                     } catch (IOException e) {
-                        onFailure(e);
+                        onFailure(e, response);
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -540,9 +546,9 @@ public class StorageBlobClientTest {
             null,
             new byte[0],
             null,
-            new Callback<Void>() {
+            new CallbackWithHeader<Void, BlockBlobStageBlockHeaders>() {
                 @Override
-                public void onResponse(Void response) {
+                public void onSuccess(Void result, BlockBlobStageBlockHeaders header, Response response) {
                     try {
                         // Then a response without body and status code 201 will be returned by the server to the callback.
                         assertNull(response);
@@ -552,9 +558,9 @@ public class StorageBlobClientTest {
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -602,7 +608,7 @@ public class StorageBlobClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        storageBlobAsyncClient.stageBlockWithRestResponse("testContainer",
+        storageBlobAsyncClient.stageBlock("testContainer",
             "testBlob",
             null,
             new byte[0],
@@ -613,21 +619,21 @@ public class StorageBlobClientTest {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlockBlobsStageBlockResponse>() {
+            new CallbackWithHeader<Void, BlockBlobStageBlockHeaders>() {
                 @Override
-                public void onResponse(BlockBlobsStageBlockResponse response) {
+                public void onSuccess(Void result, BlockBlobStageBlockHeaders header, Response response) {
                     try {
                         // Then a response without body and status code 201 will be returned by the server to the callback.
-                        assertEquals(201, response.getStatusCode());
+                        assertEquals(201, response.code());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -678,23 +684,25 @@ public class StorageBlobClientTest {
         storageBlobAsyncClient.commitBlockList("testContainer",
             "testBlob",
             null,
-            true, new Callback<BlockBlobItem>() {
+            true,
+
+            new CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders>() {
                 @Override
-                public void onResponse(BlockBlobItem response) {
+                public void onSuccess(BlockBlobItem result, BlockBlobCommitBlockListHeaders header, Response response) {
                     try {
                         // Then a response with the blob's details and status code 201 will be returned by the server to
                         // the callback.
-                        assertEquals(false, response.isServerEncrypted());
-                        assertEquals("testEtag", response.getETag());
+                        assertEquals(false, result.isServerEncrypted());
+                        assertEquals("testEtag", result.getETag());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -752,7 +760,7 @@ public class StorageBlobClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        storageBlobAsyncClient.commitBlockListWithRestResponse("testContainer",
+        storageBlobAsyncClient.commitBlockList("testContainer",
             "testBlob",
             null,
             null,
@@ -764,23 +772,25 @@ public class StorageBlobClientTest {
             null,
             null,
             null,
-            CancellationToken.NONE, new Callback<BlockBlobsCommitBlockListResponse>() {
+            CancellationToken.NONE,
+
+            new CallbackWithHeader<BlockBlobItem, BlockBlobCommitBlockListHeaders>() {
                 @Override
-                public void onResponse(BlockBlobsCommitBlockListResponse response) {
+                public void onSuccess(BlockBlobItem result, BlockBlobCommitBlockListHeaders header, Response response) {
                     try {
                         // Then a response with the blob's details and status code 201 will be returned by the server to
                         // the callback.
-                        assertEquals(false, response.getBlockBlobItem().isServerEncrypted());
-                        assertEquals("testEtag", response.getBlockBlobItem().getETag());
+                        assertEquals(false, result.isServerEncrypted());
+                        assertEquals("testEtag", result.getETag());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -821,9 +831,9 @@ public class StorageBlobClientTest {
 
         storageBlobAsyncClient.delete("container",
             "blob",
-            new Callback<Void>() {
+            new CallbackWithHeader<Void, BlobDeleteHeaders>() {
                 @Override
-                public void onResponse(Void response) {
+                public void onSuccess(Void result, BlobDeleteHeaders header, Response response) {
                     try {
                         // Then a response without body and status code 202 will be returned by the server to the callback.
                         assertNull(response);
@@ -833,9 +843,9 @@ public class StorageBlobClientTest {
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }
@@ -857,7 +867,7 @@ public class StorageBlobClientTest {
 
         // Then a response without body and status code 202 will be returned by the server.
         BlobDeleteResponse response =
-            storageBlobClient.deleteWithResponse("container",
+            storageBlobClient.deleteWithRestResponse("container",
                 "blob",
                 null,
                 null,
@@ -887,7 +897,7 @@ public class StorageBlobClientTest {
 
         CountDownLatch latch = new CountDownLatch(1);
 
-        storageBlobAsyncClient.deleteWithResponse("container",
+        storageBlobAsyncClient.delete("container",
             "blob",
             null,
             null,
@@ -900,21 +910,21 @@ public class StorageBlobClientTest {
             null,
             null,
             CancellationToken.NONE,
-            new Callback<BlobDeleteResponse>() {
+            new CallbackWithHeader<Void, BlobDeleteHeaders>() {
                 @Override
-                public void onResponse(BlobDeleteResponse response) {
+                public void onSuccess(Void result, BlobDeleteHeaders header, Response response) {
                     try {
                         // Then a response without body and status code 202 will be returned by the server to the callback.
-                        assertEquals(202, response.getStatusCode());
+                        assertEquals(202, response.code());
                     } finally {
                         latch.countDown();
                     }
                 }
 
                 @Override
-                public void onFailure(Throwable t) {
+                public void onFailure(Throwable throwable, Response response) {
                     try {
-                        throw new RuntimeException(t);
+                        throw new RuntimeException(throwable);
                     } finally {
                         latch.countDown();
                     }


### PR DESCRIPTION
As agreed during the guideline/review meeting, updating the `Callback` type to always provide raw Response (okhttp) along with the value. Adding `CallbackWithHeader` for APIs with a custom header.

Additionally, changes align the hand-written storage protocol layer to more look like a future auto-generated layer.