### PR TITLE
Remove leaking of SerializerAdapter

### DIFF
--- a/sdk/core/azure-core/src/test/java/com/azure/android/core/http/ServiceClientTest.java
+++ b/sdk/core/azure-core/src/test/java/com/azure/android/core/http/ServiceClientTest.java
@@ -2,8 +2,6 @@ package com.azure.android.core.http;
 
 import com.azure.android.core.http.interceptor.AddDateInterceptor;
 import com.azure.android.core.http.interceptor.LoggingInterceptor;
-import com.azure.android.core.internal.util.serializer.SerializerAdapter;
-import com.azure.android.core.internal.util.serializer.SerializerFormat;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -27,7 +25,6 @@ public class ServiceClientTest {
     public static void setUp() {
         serviceClient = new ServiceClient.Builder()
             .setBaseUrl(BASE_URL)
-            .setSerializationFormat(SerializerFormat.JSON)
             .build();
     }
 
@@ -42,11 +39,6 @@ public class ServiceClientTest {
     @Test
     public void getBaseUrl() {
         assertEquals(BASE_URL, serviceClient.getBaseUrl());
-    }
-
-    @Test
-    public void getSerializerAdapter() {
-        assertEquals(SerializerAdapter.createDefault(), serviceClient.getSerializerAdapter());
     }
 
     @Test
@@ -66,7 +58,6 @@ public class ServiceClientTest {
             .setConnectionPool(new ConnectionPool())
             .addNetworkInterceptor(new LoggingInterceptor(null))
             .addInterceptor(new AddDateInterceptor())
-            .setSerializationFormat(SerializerFormat.JSON)
             .setBaseUrl(BASE_URL)
             .setConnectionTimeout(100, TimeUnit.SECONDS)
             .setCredentialsInterceptor((Interceptor) chain -> chain.proceed(chain.request()))
@@ -79,7 +70,6 @@ public class ServiceClientTest {
         assertNotNull(retrofit);
         assertEquals(BASE_URL, retrofit.baseUrl().toString());
         assertEquals(BASE_URL, otherServiceClient.getBaseUrl());
-        assertEquals(SerializerAdapter.createDefault(), otherServiceClient.getSerializerAdapter());
     }
 
     @Test
@@ -87,7 +77,6 @@ public class ServiceClientTest {
         ServiceClient otherServiceClient = serviceClient.newBuilder()
             .addNetworkInterceptor(new LoggingInterceptor(null))
             .addInterceptor(new AddDateInterceptor())
-            .setSerializationFormat(SerializerFormat.JSON)
             .build();
 
         Retrofit retrofit = serviceClient.getRetrofit();
@@ -95,14 +84,12 @@ public class ServiceClientTest {
 
         assertEquals(retrofit.baseUrl().toString(), otherRetrofit.baseUrl().toString());
         assertEquals(serviceClient.getBaseUrl(), otherServiceClient.getBaseUrl());
-        assertEquals(serviceClient.getSerializerAdapter(), otherServiceClient.getSerializerAdapter());
     }
 
     @Test
     public void buildClient_withNoSlashAtTheEndOfBaseUrl() {
         ServiceClient otherServiceClient = new ServiceClient.Builder()
             .setBaseUrl("http://127.0.0.1")
-            .setSerializationFormat(SerializerFormat.JSON)
             .build();
 
         assertEquals("http://127.0.0.1/", otherServiceClient.getBaseUrl());
@@ -111,14 +98,6 @@ public class ServiceClientTest {
     @Test(expected = IllegalArgumentException.class)
     public void buildClient_withNoBaseUrl_willThrowException() {
         ServiceClient otherServiceClient = new ServiceClient.Builder()
-            .setSerializationFormat(SerializerFormat.JSON)
-            .build();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void buildClient_withNoSerializationFormat_willThrowException() {
-        ServiceClient otherServiceClient = new ServiceClient.Builder()
-            .setBaseUrl(BASE_URL)
             .build();
     }
 

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobAsyncClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobAsyncClient.java
@@ -16,7 +16,6 @@ import androidx.work.NetworkType;
 import com.azure.android.core.http.Callback;
 import com.azure.android.core.http.ServiceClient;
 import com.azure.android.core.http.interceptor.AddDateInterceptor;
-import com.azure.android.core.internal.util.serializer.SerializerFormat;
 import com.azure.android.core.util.CancellationToken;
 import com.azure.android.core.util.CoreUtil;
 import com.azure.android.storage.blob.models.AccessTier;
@@ -698,8 +697,7 @@ public class StorageBlobAsyncClient {
         public Builder(String storageBlobClientId) {
             this(storageBlobClientId, new ServiceClient.Builder());
             this.serviceClientBuilder
-                .addInterceptor(new AddDateInterceptor())
-                .setSerializationFormat(SerializerFormat.XML);
+                .addInterceptor(new AddDateInterceptor());
         }
 
         /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobClient.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 
 import com.azure.android.core.http.ServiceClient;
 import com.azure.android.core.http.interceptor.AddDateInterceptor;
-import com.azure.android.core.internal.util.serializer.SerializerFormat;
 import com.azure.android.core.util.CancellationToken;
 import com.azure.android.storage.blob.models.AccessTier;
 import com.azure.android.storage.blob.models.BlobDeleteResponse;
@@ -496,8 +495,7 @@ public class StorageBlobClient {
         public Builder() {
             this(new ServiceClient.Builder());
             this.serviceClientBuilder
-                .addInterceptor(new AddDateInterceptor())
-                .setSerializationFormat(SerializerFormat.XML);
+                .addInterceptor(new AddDateInterceptor());
         }
 
         /**

--- a/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobServiceImpl.java
+++ b/sdk/storage/azure-storage-blob/src/main/java/com/azure/android/storage/blob/StorageBlobServiceImpl.java
@@ -72,7 +72,7 @@ final class StorageBlobServiceImpl {
 
     StorageBlobServiceImpl(ServiceClient serviceClient) {
         this.service = serviceClient.getRetrofit().create(StorageBlobService.class);
-        this.serializerAdapter = serviceClient.getSerializerAdapter();
+        this.serializerAdapter = SerializerAdapter.createDefault();
     }
 
     List<BlobItem> getBlobsInPage(String pageId,

--- a/sdk/storage/azure-storage-blob/src/test/java/com/azure/android/storage/blob/StorageBlobClientTest.java
+++ b/sdk/storage/azure-storage-blob/src/test/java/com/azure/android/storage/blob/StorageBlobClientTest.java
@@ -41,13 +41,11 @@ public class StorageBlobClientTest {
     private static final String BASE_URL = mockWebServer.url("/").toString();
     private static StorageBlobAsyncClient storageBlobAsyncClient = new StorageBlobAsyncClient.Builder("client.test.1",
         new ServiceClient.Builder()
-            .setBaseUrl(BASE_URL)
-            .setSerializationFormat(SerializerFormat.XML))
+            .setBaseUrl(BASE_URL))
         .build();
 
     private static StorageBlobClient storageBlobClient = new StorageBlobClient.Builder(new ServiceClient.Builder()
-            .setBaseUrl(BASE_URL)
-            .setSerializationFormat(SerializerFormat.XML))
+            .setBaseUrl(BASE_URL))
         .build();
 
     @After


### PR DESCRIPTION
This PR backports changes from pr repo: https://github.com/Azure/azure-sdk-for-android-pr/pull/8

The `SerializerAdapter` is an internal type that should not be exposed to public API. In the future, we may support a pluggable serializer and may make this or a similar type a part of public API.

In AutoRest Generated Android code, we'll use the content-type response header to pick the right serialization format, (like java azure-core does).

The retrofit ConvertorFactory is removed, given its NOP in the azure android SDK case, the internal retrofit APIs takes `Body` and return `ResponseBody` so these converters are never used.

