### PR TITLE
Add NOTICE.md and LICENSE.md to the exclusion list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,10 @@ configure(subprojects.findAll { it.path.startsWith(':sdk:') && it.path.count(':'
         packagingOptions {
             exclude 'META-INF/DEPENDENCIES'
             exclude 'META-INF/LICENSE'
+            exclude 'META-INF/LICENSE.md'
             exclude 'META-INF/license'
             exclude 'META-INF/NOTICE'
+            exclude 'META-INF/NOTICE.md'
             exclude 'META-INF/notice'
             exclude 'META-INF/ASL2.0'
             exclude("META-INF/*.md")


### PR DESCRIPTION
by default when Gradle tool packages ARR, it apply some [exclusion](https://android.googlesource.com/platform/tools/base/+/gradle_2.0.0/build-system/gradle-core/src/main/groovy/com/android/build/gradle/internal/dsl/PackagingOptions.java#31) settings:

i.e. following are excluded by default:

```java
Set<String> excludes = Sets.newHashSet(
    "META-INF/LICENSE",
    "META-INF/LICENSE.txt",
    "META-INF/NOTICE",
    "META-INF/NOTICE.txt",
    "NOTICE",
    "NOTICE.txt",
    "LICENSE.txt",
    "LICENSE");
```
This default exclusion list does not contain LICENSE.md and NOTICE.md that azure-android-sdk include. 

This result in error like "More than one file was found with OS independent path 'META-INF/LICENSE.md" in the consuming side and application developer is requird to add exclusions in their app. This PR add, those two files to exclusion list.

Note: ARR libraries indeed add exclusion for similar additional files. Here is an [example](https://github.com/mockk/mockk/blob/10f17de9645f71245e8f3e11e25f9424ab911f0d/mockk/android/build.gradle#L19).