### PR TITLE
Exposing okhttp and time as api

### DIFF
--- a/sdk/core/azure-core/build.gradle
+++ b/sdk/core/azure-core/build.gradle
@@ -11,13 +11,13 @@ android {
 }
 
 dependencies {
+    api "com.jakewharton.threetenabp:threetenabp:$threeTenAbpVersion"
+    api "com.squareup.okhttp3:okhttp:$okHttpVersion"
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "androidx.annotation:annotation:$annotationsVersion"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycleVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion"
-    implementation "com.jakewharton.threetenabp:threetenabp:$threeTenAbpVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "javax.xml.stream:stax-api:$staxApiVersion" // https://stackoverflow.com/a/47371517/1473510
     testImplementation "androidx.appcompat:appcompat:$appCompatVersion"


### PR DESCRIPTION
Our public API includes OkHttp and Thirteenbp types. In core's gradle its scoped to "implementation". This means, consumers would have to add the same two dependency in their app :( We can mark them as "api" ("implementation" -> "api") so that it's transitively available.
