### PR TITLE
Added Core Options types: ClientOptions, RequestOptions and TransportOptions

### DIFF
--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.3 (Unreleased)
 
+### New Features
+
+- Added `ClientOptions`, `RequestOptions` and `TransportOptions`.
+
 ## 1.0.0-beta.2 (2020-10-05)
 
 ### New Features

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/ClientOptions.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/ClientOptions.java
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.http.options;
+
+import androidx.annotation.NonNull;
+
+import com.azure.android.core.http.ServiceClient;
+import com.azure.android.core.util.logging.ClientLogger;
+
+/**
+ * Options for configuring a {@link ServiceClient}.
+ */
+public class ClientOptions {
+    @NonNull
+    private final String apiVersion;
+    @NonNull
+    private final ClientLogger logger;
+    @NonNull
+    private final TelemetryOptions telemetryOptions;
+    @NonNull
+    private final TransportOptions transportOptions;
+
+    /**
+     * Creates an instance of {@link ClientOptions} without {@link TelemetryOptions} and {@link TransportOptions}.
+     *
+     * @param apiVersion The API version of the service to invoke.
+     * @param logger     The {@link ClientLogger} to be used by the {@link ServiceClient}.
+     */
+    public ClientOptions(@NonNull String apiVersion, @NonNull ClientLogger logger) {
+        this(apiVersion, logger, new TelemetryOptions(false, null), new TransportOptions(null, null));
+    }
+
+    /**
+     * Creates an instance of {@link ClientOptions}.
+     *
+     * @param apiVersion       The API version of the service to invoke.
+     * @param logger           The {@link ClientLogger} to be used by the {@link ServiceClient}.
+     * @param telemetryOptions Options for configuring telemetry sent by the {@link ServiceClient}.
+     * @param transportOptions Options for configuring calls made by the {@link ServiceClient}.
+     */
+    public ClientOptions(@NonNull String apiVersion, @NonNull ClientLogger logger,
+                         @NonNull TelemetryOptions telemetryOptions, @NonNull TransportOptions transportOptions) {
+        this.apiVersion = apiVersion;
+        this.logger = logger;
+        this.telemetryOptions = telemetryOptions;
+        this.transportOptions = transportOptions;
+    }
+
+    /**
+     * Gets the service API version the {@link ServiceClient} will use when making calls.
+     *
+     * @return The service API version.
+     */
+    @NonNull
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * Gets the {@link ServiceClient client}'s logger.
+     *
+     * @return The {@link ClientLogger}.
+     */
+    @NonNull
+    public ClientLogger getLogger() {
+        return logger;
+    }
+
+    /**
+     * Gets the {@link ServiceClient client}'s {@link TelemetryOptions}.
+     *
+     * @return The {@link TelemetryOptions}.
+     */
+    @NonNull
+    public TelemetryOptions getTelemetryOptions() {
+        return telemetryOptions;
+    }
+
+    /**
+     * Gets the {@link ServiceClient client}'s {@link TransportOptions}.
+     *
+     * @return The {@link TransportOptions}.
+     */
+    @NonNull
+    public TransportOptions getTransportOptions() {
+        return transportOptions;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/RequestOptions.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/RequestOptions.java
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.http.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.azure.android.core.http.ServiceClient;
+import com.azure.android.core.util.CancellationToken;
+
+/**
+ * Options for a service operation to be carried out by a {@link ServiceClient}.
+ */
+public class RequestOptions {
+    @Nullable
+    private final String clientRequestId;
+    @NonNull
+    private final CancellationToken cancellationToken;
+
+    /**
+     * Creates an instance of {@link RequestOptions}.
+     *
+     * @param clientRequestId   A client-generated, opaque value with 1KB character limit that is recorded in analytics
+     *                          logs. Highly recommended for correlating client-side activities with requests received
+     *                          by the server.
+     * @param cancellationToken A token used to make a best-effort attempt at canceling a request.
+     */
+    public RequestOptions(@Nullable String clientRequestId, CancellationToken cancellationToken) {
+        this.clientRequestId = clientRequestId;
+        this.cancellationToken = cancellationToken == null ? CancellationToken.NONE : cancellationToken;
+    }
+
+    /**
+     * Get the service operation's unique request ID.
+     *
+     * @return The request ID.
+     */
+    @Nullable
+    public String getClientRequestId() {
+        return clientRequestId;
+    }
+
+    /**
+     * Get the {@link CancellationToken} associated to the service operation.
+     *
+     * @return The {@link CancellationToken}.
+     */
+    @NonNull
+    public CancellationToken getCancellationToken() {
+        return cancellationToken;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/TelemetryOptions.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/TelemetryOptions.java
@@ -11,9 +11,9 @@ import com.azure.android.core.http.ServiceClient;
  * Options for configuring telemetry sent by a {@link ServiceClient}.
  */
 public class TelemetryOptions {
-    boolean telemetryDisabled;
+    private final boolean telemetryDisabled;
     @Nullable
-    String applicationId;
+    private final String applicationId;
 
     /**
      * Creates an instance of {@link TelemetryOptions}.

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/TransportOptions.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/TransportOptions.java
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.core.http.options;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.azure.android.core.http.ServiceClient;
+import com.azure.android.core.http.interceptor.RetryStrategy;
+
+import org.threeten.bp.Duration;
+
+/**
+ * Options for configuring calls made by a {@link ServiceClient}.
+ */
+public class TransportOptions {
+    @NonNull
+    private final Duration timeout;
+    @Nullable
+    private final RetryStrategy retryStrategy;
+
+    /**
+     * Creates an instance of {@link TransportOptions}.
+     *
+     * @param timeout       Default timeout on any network call. 0 (zero) means there is no timeout.
+     * @param retryStrategy The {@link RetryStrategy} to be used for calls made by the {@link ServiceClient}.
+     */
+    public TransportOptions(@Nullable Duration timeout, @Nullable RetryStrategy retryStrategy) {
+        this.timeout = timeout == null ? Duration.ZERO : timeout;
+        this.retryStrategy = retryStrategy;
+    }
+
+    /**
+     * Gets the default timeout for calls made by the {@link ServiceClient}.
+     *
+     * @return the default timeout in seconds. 0 (zero) means there is no timeout.
+     */
+    @NonNull
+    public Duration getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Gets the {@link RetryStrategy} to be used for calls made by the {@link ServiceClient}.
+     *
+     * @return The {@link RetryStrategy}.
+     */
+    @Nullable
+    public RetryStrategy getRetryStrategy() {
+        return retryStrategy;
+    }
+}

--- a/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/TransportOptions.java
+++ b/sdk/core/azure-core/src/main/java/com/azure/android/core/http/options/TransportOptions.java
@@ -15,6 +15,7 @@ import org.threeten.bp.Duration;
  * Options for configuring calls made by a {@link ServiceClient}.
  */
 public class TransportOptions {
+    // TODO: Implement timeout logic in CancellationToken.
     @NonNull
     private final Duration timeout;
     @Nullable


### PR DESCRIPTION
Fixes #314.

`TransportOptions` includes a `timeout` property, which won't be used yet by our `CancellationToken` pending some discussions about how to properly implement such a feature.