### PR TITLE
Enable 1ES hosted pools.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -9,7 +9,7 @@ jobs:
       - template: ../variables/globals.yml
 
     pool:
-      vmImage: '$(OSVmImage)'
+      name: '$(Pool)'
 
     steps:
       - script: |
@@ -33,7 +33,7 @@ jobs:
       - template: ../variables/globals.yml
 
     pool:
-      vmImage: '$(OSVmImage)'
+      name: '$(Pool)'
 
     steps:
 
@@ -72,7 +72,7 @@ jobs:
       - template: ../variables/globals.yml
 
     pool:
-      vmImage: '$(OSVmImage)'
+      name: '$(Pool)'
 
     steps:
       - script: |

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,3 +1,3 @@
 variables:
-    OSVmImage: 'ubuntu-20.04'
+    Pool: azsdk-pool-mms-ubuntu-2004-general
     DocWardenVersion: '0.4.2'


### PR DESCRIPTION
This PR updates the global variables file, and variables usage to use the new 1ES hosted pools. We are using a 20.04 pool which at the moment is dedicated to Android builds. We don't have a huge number of pre-allocated VMs since builds in this repo are comparatively infrequent, but the pool will grow should other repos start coming onboard.

Min pool size = 5
Max pool size = 10