### PR TITLE
Making azure-core-http-httpurlconnection baselined to apiLevel-15 and azure-core-http-okhttp to apiLevel-21

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -155,4 +155,7 @@
   <suppress checks="com.azure.tools.checkstyle.checks.ThrowFromClientLogger"
       files="com.azure.android.core.http.implementation.Util.java"/>
 
+  <suppress checks="com.azure.tools.checkstyle.checks.ThrowFromClientLogger"
+      files="com.azure.android.core.http.httpurlconnection.HttpUrlConnectionAsyncHttpClientBuilder.java"/>
+
 </suppressions>

--- a/sdk/core/azure-core-http-httpurlconnection/build.gradle
+++ b/sdk/core/azure-core-http-httpurlconnection/build.gradle
@@ -5,6 +5,7 @@ ext.versionCode = 1
 
 android {
     defaultConfig {
+        minSdkVersion 15
         versionCode project.versionCode
         versionName project.version
     }

--- a/sdk/core/azure-core-http-httpurlconnection/src/main/AndroidManifest.xml
+++ b/sdk/core/azure-core-http-httpurlconnection/src/main/AndroidManifest.xml
@@ -1,5 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.azure.core.http.httpurlconnection">
+    package="com.azure.core.http.httpurlconnection"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- The azure-core-test module not a real android package to deploy to any device; it's use is limited
+          to unit-test (i.e. non-instrumentation); its marked as android-lib only to ease the reference to it
+          from the unit-test of other android packages; hence the override for minSdkVersion.
+      -->
+    <!-- The override for com.azure.core.serde.jackson & com.azure.core.rest will be removed once we complete
+         the baseline work for these two modules. -->
+    <uses-sdk tools:overrideLibrary="com.azure.core.test, com.azure.core.serde.jackson, com.azure.core.rest" />
 </manifest>

--- a/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/android/core/http/httpurlconnection/HttpUrlConnectionAsyncHttpClient.java
+++ b/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/android/core/http/httpurlconnection/HttpUrlConnectionAsyncHttpClient.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Iterator;
 import java.util.List;
@@ -303,7 +302,7 @@ class HttpUrlConnectionAsyncHttpClient implements HttpClient {
                 && bytes[0] == (byte) 0xEF
                 && bytes[1] == (byte) 0xBB
                 && bytes[2] == (byte) 0xBF) {
-                return new String(bytes, 3, bytes.length - 3, StandardCharsets.UTF_8);
+                return new String(bytes, 3, bytes.length - 3, Charset.forName("UTF-8"));
             } else if (bytes.length >= 4
                 && bytes[0] == (byte) 0x00
                 && bytes[1] == (byte) 0x00
@@ -319,11 +318,11 @@ class HttpUrlConnectionAsyncHttpClient implements HttpClient {
             } else if (bytes.length >= 2
                 && bytes[0] == (byte) 0xFE
                 && bytes[1] == (byte) 0xFF) {
-                return new String(bytes, 2, bytes.length - 2, StandardCharsets.UTF_16BE);
+                return new String(bytes, 2, bytes.length - 2, Charset.forName("UTF-16BE"));
             } else if (bytes.length >= 2
                 && bytes[0] == (byte) 0xFF
                 && bytes[1] == (byte) 0xFE) {
-                return new String(bytes, 2, bytes.length - 2, StandardCharsets.UTF_16LE);
+                return new String(bytes, 2, bytes.length - 2, Charset.forName("UTF-16LE"));
             } else {
                 /*
                  * Attempt to retrieve the default charset from the 'Content-Encoding' header,
@@ -335,13 +334,13 @@ class HttpUrlConnectionAsyncHttpClient implements HttpClient {
                         if (charsetMatcher.find()) {
                             return new String(bytes, Charset.forName(charsetMatcher.group(1)));
                         } else {
-                            return new String(bytes, StandardCharsets.UTF_8);
+                            return new String(bytes, Charset.forName("UTF-8"));
                         }
                     } catch (IllegalCharsetNameException | UnsupportedCharsetException ex) {
-                        return new String(bytes, StandardCharsets.UTF_8);
+                        return new String(bytes, Charset.forName("UTF-8"));
                     }
                 } else {
-                    return new String(bytes, StandardCharsets.UTF_8);
+                    return new String(bytes, Charset.forName("UTF-8"));
                 }
             }
         }

--- a/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/android/core/http/httpurlconnection/HttpUrlConnectionAsyncHttpClientBuilder.java
+++ b/sdk/core/azure-core-http-httpurlconnection/src/main/java/com/azure/android/core/http/httpurlconnection/HttpUrlConnectionAsyncHttpClientBuilder.java
@@ -6,8 +6,6 @@ package com.azure.android.core.http.httpurlconnection;
 import com.azure.android.core.http.HttpCallDispatcher;
 import com.azure.android.core.http.HttpClient;
 
-import java.util.Objects;
-
 /**
  * Builder class responsible for creating instances of {@link com.azure.android.core.http.HttpClient}
  * backed by HttpUrlConnection.
@@ -26,10 +24,13 @@ public class HttpUrlConnectionAsyncHttpClientBuilder {
      *
      * @param httpCallDispatcher The HTTP call dispatcher
      * @return The updated HttpUrlConnectionAsyncHttpClientBuilder object.
+     * @throws NullPointerException if the httpCallDispatcher parameter is null.
      */
     public HttpUrlConnectionAsyncHttpClientBuilder setHttpCallDispatcher(HttpCallDispatcher httpCallDispatcher) {
-        this.httpCallDispatcher
-            = Objects.requireNonNull(httpCallDispatcher, "'httpCallDispatcher' is required.");
+        if (httpCallDispatcher == null) {
+            throw new NullPointerException("'httpCallDispatcher' is required.");
+        }
+        this.httpCallDispatcher = httpCallDispatcher;
         return this;
     }
 

--- a/sdk/core/azure-core-http-okhttp/build.gradle
+++ b/sdk/core/azure-core-http-okhttp/build.gradle
@@ -5,6 +5,7 @@ ext.versionCode = 1
 
 android {
     defaultConfig {
+        minSdkVersion 21
         versionCode project.versionCode
         versionName project.version
     }

--- a/sdk/core/azure-core-http-okhttp/src/main/AndroidManifest.xml
+++ b/sdk/core/azure-core-http-okhttp/src/main/AndroidManifest.xml
@@ -1,5 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.azure.core.http.okhttp">
+    package="com.azure.core.http.okhttp"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- The azure-core-test module not a real android package to deploy to any device; it's use is limited
+          to unit-test (i.e. non-instrumentation); its marked as android-lib only to ease the reference to it
+          from the unit-test of other android packages; hence the override for minSdkVersion.
+      -->
+    <!-- The override for com.azure.core.serde.jackson & com.azure.core.rest will be removed once we complete
+         the baseline work for these two modules. -->
+    <uses-sdk tools:overrideLibrary="com.azure.core.test, com.azure.core.serde.jackson, com.azure.core.rest" />
 </manifest>
+

--- a/sdk/core/azure-core-serde/build.gradle
+++ b/sdk/core/azure-core-serde/build.gradle
@@ -5,6 +5,7 @@ ext.versionCode = 1
 
 android {
     defaultConfig {
+        minSdkVersion 15
         versionCode project.versionCode
         versionName project.version
     }


### PR DESCRIPTION
Note: The L21 baseline for azure-core-http-okhttp is due to okhttp's min API requirement of L21.
