### PR TITLE
Move android release template out of build-tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For your convenience, each service has a separate set of libraries that you can 
 
 ### Libraries available
 
-Currently, the client libraries are in **beta**. These libraries follow the [Azure SDK Design Guidelines for Android](https://azure.github.io/azure-sdk/android_introduction.html) and share a number of core features such as HTTP retries, logging, transport protocols, authentication protocols, etc., so that once you learn how to use these features in one client library, you will know how to use them in other client libraries. You can learn about these shared features in [azure-core](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/core/azure-core/README.md).
+Currently, the client libraries are in **beta**. These libraries follow the [Azure SDK Design Guidelines for Android](https://azure.github.io/azure-sdk/design.html) and share a number of core features such as HTTP retries, logging, transport protocols, authentication protocols, etc., so that once you learn how to use these features in one client library, you will know how to use them in other client libraries. You can learn about these shared features in [azure-core](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/core/azure-core/README.md).
 
 The following libraries are currently in **beta**:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For your convenience, each service has a separate set of libraries that you can 
 
 ### Libraries available
 
-Currently, the client libraries are in **beta**. These libraries follow the [Azure SDK Design Guidelines for Android](https://azure.github.io/azure-sdk/design.html) and share a number of core features such as HTTP retries, logging, transport protocols, authentication protocols, etc., so that once you learn how to use these features in one client library, you will know how to use them in other client libraries. You can learn about these shared features in [azure-core](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/core/azure-core/README.md).
+Currently, the client libraries are in **beta**. These libraries follow the [Azure SDK Design Guidelines for Android](https://azure.github.io/azure-sdk/android_design.html) and share a number of core features such as HTTP retries, logging, transport protocols, authentication protocols, etc., so that once you learn how to use these features in one client library, you will know how to use them in other client libraries. You can learn about these shared features in [azure-core](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/core/azure-core/README.md).
 
 The following libraries are currently in **beta**:
 

--- a/eng/pipelines/templates/stages/archetype-android-release.yml
+++ b/eng/pipelines/templates/stages/archetype-android-release.yml
@@ -1,0 +1,125 @@
+parameters:
+  Artifacts: []
+  ArtifactName: 'not-specified'
+
+stages:
+  # The signing stage is responsible for submitting binaries to ESRP for our official signing
+  # where appropriate and also meeting any other signing requirements for particular artifacts,
+  # in this case we do GPG signing in order to publish to Maven Central. At the moment signing
+  # is protected by an approval check but this may be removed in the future.
+  - stage: Signing
+    dependsOn: ${{parameters.DependsOn}}
+    jobs:
+      - deployment: SignPackage
+        environment: esrp
+        timeoutInMinutes: 20
+        pool:
+          vmImage: ubuntu-16.04
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: azure-sdk-build-tools
+                  path: azure-sdk-build-tools
+
+                - download: current
+                  artifact: ${{parameters.ArtifactName}}
+                  timeoutInMinutes: 5
+
+                - template: /tools/java-esrp-signing/java-esrp-signing.yml@azure-sdk-build-tools
+                  parameters:
+                    Artifacts: ${{parameters.Artifacts}}
+                    ArtifactDirectory: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+
+                - publish: $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+                  artifact: ${{parameters.ArtifactName}}-signed
+                  displayName: 'Store signed packages in ${{parameters.ArtifactName}}-signed artifact'
+                  timeoutInMinutes: 5
+
+  # We generate two interdepdent stages for each artifact listed in the ci.yml file, creates the release
+  # in GitHub. The Release stage publishes to Maven Central. Both stages require approval since they
+  # effectively burn the version number. For testing of packages prior to burning the version number -
+  # the Validation step below publishes a package to a "burner" feed which is cleaned up after the
+  # pipeline completes.
+  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - ${{ each artifact in parameters.Artifacts }}:
+      - stage: Release_${{artifact.safeName}}
+        displayName: 'Release: ${{artifact.name}}'
+        dependsOn: Signing
+        condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-android-pr'))
+        jobs:
+          - deployment: TagRepository
+            displayName: "Create release tag"
+            condition: ne(variables['Skip.TagRepository'], 'true')
+            environment: github
+            timeoutInMinutes: 5
+            dependsOn:
+              - ${{ if eq(parameters.VerifyVersions, 'true')}}:
+                - VerifyReleaseVersion
+
+            pool:
+              vmImage: vs2017-win2016
+
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: azure-sdk-build-tools
+                      path: azure-sdk-build-tools
+                    - pwsh: |
+                        $(Pipeline.Workspace)/azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 -artifactLocation $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.safeName}} -packageRepository Maven -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Name)
+                      displayName: 'Verify Package Tags and Create Git Releases'
+                      timeoutInMinutes: 5
+                      workingDirectory: $(Pipeline.Workspace)
+                      env:
+                        GH_TOKEN: $(azuresdk-github-pat)
+
+          - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
+            - deployment: PublishPackage
+              displayName: "Publish to Maven Central"
+              condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+              environment: maven
+              dependsOn: TagRepository
+
+              pool:
+                vmImage: vs2017-win2016
+                
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: azure-sdk-build-tools
+                        path: azure-sdk-build-tools
+                      - template: /tools/gpg/gpg.yml@azure-sdk-build-tools
+                      - template: /tools/java-publishing/java-publishing.yml@azure-sdk-build-tools
+                        parameters:
+                          ArtifactID: ${{artifact.name}}
+                          GroupID: ${{artifact.groupId}}
+                          ArtifactDirectory: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
+                          Target: MavenCentral
+
+          - ${{if ne(artifact.options.skipPublishDocs, 'true')}}:
+            - deployment: PublishDocs
+              displayName: Publish Docs to GitHubIO Blob Storage
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+              environment: githubio
+              dependsOn: PublishPackage
+
+              pool:
+                vmImage: windows-2019
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: azure-sdk-build-tools
+                        path: azure-sdk-build-tools
+                      - template: /tools/generic-blob-upload/publish-blobs.yml@azure-sdk-build-tools
+                        parameters:
+                          FolderForUpload: '$(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.safeName}}'
+                          BlobSASKey: '$(azure-sdk-docs-prod-sas)'
+                          BlobName: '$(azure-sdk-docs-prod-blob-name)'
+                          TargetLanguage: 'android'
+                          # we override the regular script path because we have cloned the build tools repo as a separate artifact.
+                          ScriptPath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/copy-docs-to-blobstorage.ps1'

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -12,7 +12,7 @@ stages:
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: pipelines/stages/archetype-android-release.yml@azure-sdk-build-tools
+    - template: archetype-android-release.yml
       parameters:
         DependsOn: Build
         Artifacts: ${{parameters.Artifacts}}


### PR DESCRIPTION
This is the first in a series of PRs that I want to land where I move the release templates for Android out of the build-tools repository.