### PR TITLE
Extend Check Enforcer timeout

### DIFF
--- a/eng/CHECKENFORCER
+++ b/eng/CHECKENFORCER
@@ -1,6 +1,6 @@
 format: v0.1-alpha
 minimumCheckRuns: 1
-timeout: 5
+timeout: 10
 message: >
   This pull request is protected by [Check Enforcer](https://aka.ms/azsdk/check-enforcer).
 


### PR DESCRIPTION
Extend the timeout that Check Enforcer applies when waiting for a pipeline to start.