### PR TITLE
Disable retain runs while sorting out issue with script location.

### DIFF
--- a/eng/pipelines/templates/stages/archetype-android-release.yml
+++ b/eng/pipelines/templates/stages/archetype-android-release.yml
@@ -66,7 +66,6 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - template: /eng/common/pipelines/templates/steps/retain-run.yml
                     - checkout: azure-sdk-build-tools
                       path: azure-sdk-build-tools
                     - pwsh: |


### PR DESCRIPTION
Disabling retain runs whilst the script location is sorted out (this is due to a difference between the Java and Android EngSys).