### PR TITLE
Added missing Trouter client init step for connection status

### DIFF
--- a/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/implementation/signaling/CommunicationSignalingClient.java
+++ b/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/implementation/signaling/CommunicationSignalingClient.java
@@ -12,6 +12,7 @@ import com.microsoft.trouterclient.ISelfHostedTrouterClient;
 import com.microsoft.trouterclient.ITrouterAuthHeadersProvider;
 import com.microsoft.trouterclient.ITrouterConnectionDataCache;
 import com.microsoft.trouterclient.TrouterClientHost;
+import com.microsoft.trouterclient.UserActivityState;
 import com.microsoft.trouterclient.registration.ISkypetokenProvider;
 import com.microsoft.trouterclient.registration.TrouterSkypetokenAuthHeaderProvider;
 import com.microsoft.trouterclient.registration.TrouterUrlRegistrar;
@@ -99,6 +100,7 @@ public class CommunicationSignalingClient implements SignalingClient {
                 new InMemoryConnectionDataCache(), TROUTER_HOSTNAME);
             trouter.withRegistrar(registrar);
             trouter.start();
+            trouter.setUserActivityState(UserActivityState.ACTIVITY_ACTIVE);
         } catch (Throwable e) {
             logger.error(e.getMessage());
         }


### PR DESCRIPTION
Added missing Trouter client init step for connection status, requested by the Dynamics team in JS. Not requested in Android, but it would be good to have it for the future