### PR TITLE
Move version property to gradle.properties file, add versioning tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,14 @@ configure(subprojects.findAll { it.path.startsWith(':sdk:') && it.path.count(':'
         archiveClassifier.set("javadoc")
     }
 
+    task updatePackageVersion(type: WriteProperties) {
+        if (project.properties["newVersion"])
+        {
+            outputFile = file('gradle.properties')
+            property 'version', project.getProperty("newVersion")
+        }
+    }
+
     project.afterEvaluate {
         javadoc.classpath += files(android.libraryVariants.collect { variant ->
             variant.javaCompileProvider.get().classpath.files

--- a/eng/scripts/Update-PkgVersion.ps1
+++ b/eng/scripts/Update-PkgVersion.ps1
@@ -1,0 +1,31 @@
+
+[CmdletBinding()]
+Param (
+  [Parameter(Mandatory=$True)]
+  [string] $PackageName,
+  [string] $NewVersionString,
+  [string] $ReleaseDate
+)
+
+. (Join-Path $PSScriptRoot ".." common scripts common.ps1)
+
+$pkgProperties = Get-PkgProperties -PackageName $PackageName
+$packageVersion = $pkgProperties.Version
+
+$packageSemVer = [AzureEngSemanticVersion]::new($packageVersion)
+
+if ([System.String]::IsNullOrEmpty($NewVersionString))
+{
+    $packageSemVer.IncrementAndSetToPrerelease()
+    & "${EngCommonScriptsDir}/Update-ChangeLog.ps1" -Version $packageSemVer.ToString() `
+    -ChangelogPath $pkgProperties.ChangeLogPath -Unreleased $True
+}
+else
+{
+    $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
+    & "${EngCommonScriptsDir}/Update-ChangeLog.ps1" -Version $packageSemVer.ToString() `
+    -ChangelogPath $pkgProperties.ChangeLogPath -Unreleased $False `
+    -ReplaceLatestEntryTitle $True -ReleaseDate $ReleaseDate
+}
+
+gradle ":sdk:$($pkgProperties.ServiceDirectory):$($pkgProperties.Name):updatePackageVersion" -q -PnewVersion="$($packageSemVer.ToString())"

--- a/sdk/communication/azure-communication-chat/build.gradle
+++ b/sdk/communication/azure-communication-chat/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Client Library Chat SDK For Communication Service"
 description = "This package contains the Android client library Chat SDK for Microsoft Azure Communication Service."
-version = "1.1.0-beta.3"
 ext.versionCode = 1
 
 android {

--- a/sdk/communication/azure-communication-chat/gradle.properties
+++ b/sdk/communication/azure-communication-chat/gradle.properties
@@ -1,0 +1,1 @@
+version=1.1.0-beta.3

--- a/sdk/communication/azure-communication-common/build.gradle
+++ b/sdk/communication/azure-communication-common/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Client Library common code For Communication Service"
 description = "This package contains the Android client library common code for Microsoft Azure Communication Service."
-version = "1.1.0-beta.1"
 ext.versionCode = 1
 
 android {

--- a/sdk/communication/azure-communication-common/gradle.properties
+++ b/sdk/communication/azure-communication-common/gradle.properties
@@ -1,0 +1,1 @@
+version=1.1.0-beta.1

--- a/sdk/core/azure-core-credential/build.gradle
+++ b/sdk/core/azure-core-credential/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core Credential Library"
 description = "This package contains core credential types for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-credential/gradle.properties
+++ b/sdk/core/azure-core-credential/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-http-httpurlconnection/build.gradle
+++ b/sdk/core/azure-core-http-httpurlconnection/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core HttpUrlConnection Library"
 description = "This package contains HTTP implementation using HttpUrlConnection for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-http-httpurlconnection/gradle.properties
+++ b/sdk/core/azure-core-http-httpurlconnection/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-http-okhttp/build.gradle
+++ b/sdk/core/azure-core-http-okhttp/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core HTTP OkHttp Library"
 description = "This package contains HTTP implementation using OkHttp for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-http-okhttp/gradle.properties
+++ b/sdk/core/azure-core-http-okhttp/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-http/build.gradle
+++ b/sdk/core/azure-core-http/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core HTTP Library"
 description = "This package contains core HTTP types for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-http/gradle.properties
+++ b/sdk/core/azure-core-http/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-jackson/build.gradle
+++ b/sdk/core/azure-core-jackson/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Serde Jackson Library"
 description = "This package contains Serde implementation using Jackson for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-jackson/gradle.properties
+++ b/sdk/core/azure-core-jackson/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-logging/build.gradle
+++ b/sdk/core/azure-core-logging/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core Logging Library"
 description = "This package contains core logging types for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-logging/gradle.properties
+++ b/sdk/core/azure-core-logging/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-rest/build.gradle
+++ b/sdk/core/azure-core-rest/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core Rest Library"
 description = "This package contains core types to intract with a REST endpoint."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-rest/gradle.properties
+++ b/sdk/core/azure-core-rest/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core-test/build.gradle
+++ b/sdk/core/azure-core-test/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core Test Library"
 description = "This package contains core types for testing Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core-test/gradle.properties
+++ b/sdk/core/azure-core-test/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7

--- a/sdk/core/azure-core/build.gradle
+++ b/sdk/core/azure-core/build.gradle
@@ -1,6 +1,5 @@
 ext.publishName = "Microsoft Azure Android Core Library"
 description = "This package contains core types for Azure Android clients."
-version = "1.0.0-beta.7"
 ext.versionCode = 1
 
 android {

--- a/sdk/core/azure-core/gradle.properties
+++ b/sdk/core/azure-core/gradle.properties
@@ -1,0 +1,1 @@
+version=1.0.0-beta.7


### PR DESCRIPTION
I propose that we move the package versions  for all packages to `gradle.properties` file to allow for easier changes to them. 

Added task for updating the version in the gradle.properties file.
Added common script for updating the package version.