### PR TITLE
Downgraded Gradle version to fix issues with the ACS Communication pipeline.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     ext {
         googleGmsServicesPluginVersion = "4.3.8"
         gradleAndroidBuildToolsPluginVersion = "30.0.3"
-        gradleAndroidToolsPluginVersion = "4.2.1"
+        gradleAndroidToolsPluginVersion = "4.0.1"
         gradleJunitJacocoPluginVersion = "0.16.0"
         gradleDexcountPluginVersion = "3.0.0"
         gradleSpotbugsPluginVersion = "4.7.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip


### PR DESCRIPTION
This error was introduced in [this PR](https://github.com/Azure/azure-sdk-for-android/pull/865) where we updated our versions for dependencies and other tools along some other changes for the next Azure Core beta release.

Here's [an example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1089473&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=45ee1ca9-5b97-59ac-94ed-a114ab499701) of a failing pipeline.

Also, for some reason we cannot run the `android - communication - ci` pipeline even when manually triggering it in GitHub, the bot complains that said pipeline is explicitly excluded for changes to these files.