### PR TITLE
Hotfix/azure communication chat 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following libraries are currently **generally available**:
 
 #### Azure Communication Services
 - [azure-communication-calling](https://search.maven.org/artifact/com.azure.android/azure-communication-calling): 1.0.0
-- [azure-communication-chat](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/communication/azure-communication-chat): 1.0.0
+- [azure-communication-chat](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/communication/azure-communication-chat): 1.0.1
 - [azure-communication-common](https://github.com/Azure/azure-sdk-for-android/blob/master/sdk/communication/azure-communication-common): 1.0.1
 
 ### Install the libraries
@@ -52,13 +52,13 @@ For each library you wish to use, add an `implementation` configuration to the `
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-chat:1.0.0"
+    implementation "com.azure.android:azure-communication-chat:1.0.1"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-chat:1.0.0")
+    implementation("com.azure.android:azure-communication-chat:1.0.1")
 }
 ```
 
@@ -69,7 +69,7 @@ To import one or more client libraries into your project using the [Maven](https
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-chat</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ allprojects {
         annotationsVersion = "1.1.0"
         appCompatVersion = "1.2.0"
         archCoreTestVersion = "2.1.0"
+        azureCommunicationCommonVersion = "1.0.1"
         azureCoreVersion = "1.0.0-beta.6"
         concurrentFuturesVersion = "1.0.0"
         dataproviderVersion =  "2.6"

--- a/build.gradle
+++ b/build.gradle
@@ -247,7 +247,7 @@ allprojects {
         appCompatVersion = "1.2.0"
         archCoreTestVersion = "2.1.0"
         azureCommunicationCommonVersion = "1.0.1"
-        azureCoreVersion = "1.0.0-beta.6"
+        azureCoreVersion = "1.0.0-beta.7"
         concurrentFuturesVersion = "1.0.0"
         dataproviderVersion =  "2.6"
         jacksonVersion = "2.11.2"
@@ -261,7 +261,7 @@ allprojects {
         staxApiVersion = "1.0-2"
         threeTenAbpVersion = "1.3.0"
         threeTenBpVersion = "1.5.0"
-        trouterVersion = "0.0.1-beta.3"
+        trouterVersion = "0.1.1"
         workVersion = "2.4.0"
     }
 }

--- a/samples/sample-chat-app/src/main/java/com/azure/android/communication/chat/sampleapp/MainActivity.java
+++ b/samples/sample-chat-app/src/main/java/com/azure/android/communication/chat/sampleapp/MainActivity.java
@@ -82,7 +82,7 @@ public class MainActivity extends AppCompatActivity {
     private final String endpoint = "";
     private final String sdkVersion = "1.0.1";
     private static final String SDK_NAME = "azure-communication-com.azure.android.communication.chat";
-    private static final String APPLICATION_ID = "Chat Test App";
+    private static final String APPLICATION_ID = "Chat_Test_App";
     private static final String TAG = "[Chat Test App]";
     private final Queue<String> unreadMessages = new ConcurrentLinkedQueue<>();
     private static RealTimeNotificationCallback messageReceivedHandler;

--- a/samples/sample-chat-app/src/main/java/com/azure/android/communication/chat/sampleapp/MainActivity.java
+++ b/samples/sample-chat-app/src/main/java/com/azure/android/communication/chat/sampleapp/MainActivity.java
@@ -80,7 +80,7 @@ public class MainActivity extends AppCompatActivity {
     private String threadId = "<to-be-updated-below>";
     private String chatMessageId = "<to-be-updated-below>";
     private final String endpoint = "";
-    private final String sdkVersion = "1.0.0";
+    private final String sdkVersion = "1.0.1";
     private static final String SDK_NAME = "azure-communication-com.azure.android.communication.chat";
     private static final String APPLICATION_ID = "Chat Test App";
     private static final String TAG = "[Chat Test App]";

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Release History
-## 1.0.1 (2021-09-03)
+## 1.0.1 (2021-09-15)
 - Version update.
-- Stop realtime notifications properly after the provided skype user token expired.
 
 ## 1.0.0 (2021-06-15)
 ### New Features

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Release History
+## 1.0.1 (2021-09-03)
+- Version update.
+- Stop realtime notifications properly after the provided skype user token expired.
+
 ## 1.0.0 (2021-06-15)
 ### New Features
 - Added `ChatServiceVersion` and the ability to set it on `ChatClientBuilder` and `ChatThreadClientBuilder`.

--- a/sdk/communication/azure-communication-chat/README.md
+++ b/sdk/communication/azure-communication-chat/README.md
@@ -15,7 +15,7 @@ Azure Communication Chat contains the APIs used in chat applications for Azure C
 - A deployed Communication Services resource. You can use the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp) or the [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.communication/new-azcommunicationservice) to set it up.
 
 ### Versions available
-The current version of this library is **1.0.0**.
+The current version of this library is **1.0.1**.
 
 ### Include the package
 To install the Azure Communication Chat libraries for Android, add them as dependencies within your
@@ -31,13 +31,13 @@ Add an `implementation` configuration to the `dependencies` block of your app's 
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-chat:1.0.0"
+    implementation "com.azure.android:azure-communication-chat:1.0.1"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-chat:1.0.0")
+    implementation("com.azure.android:azure-communication-chat:1.0.1")
 }
 ```
 
@@ -48,7 +48,7 @@ To import the library into your project using the [Maven](https://maven.apache.o
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-chat</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 

--- a/sdk/communication/azure-communication-chat/build.gradle
+++ b/sdk/communication/azure-communication-chat/build.gradle
@@ -1,6 +1,6 @@
 ext.publishName = "Microsoft Azure Android Client Library Chat SDK For Communication Service"
 description = "This package contains the Android client library Chat SDK for Microsoft Azure Communication Service."
-version = "1.0.0"
+version = "1.0.1"
 ext.versionCode = 1
 
 android {
@@ -42,7 +42,7 @@ dependencies {
 
     api "net.sourceforge.streamsupport:android-retrofuture:$retroFutureVersion"
 
-    api project(":sdk:communication:azure-communication-common")
+    api "com.azure.android:azure-communication-common:$azureCommunicationCommonVersion"
     // <!-- end: api Dependencies -->
 
     // <!-- begin: implementation Dependencies -->

--- a/sdk/communication/azure-communication-chat/env-prod.properties
+++ b/sdk/communication/azure-communication-chat/env-prod.properties
@@ -1,5 +1,5 @@
 trouter.client.version="99116/0.0.0.0/"
-trouter.max.registration.ttls="3600"
+trouter.max.registration.ttls="3601"
 platform="SPOOL"
 platform.ui.version="0.0.0.0"
 

--- a/sdk/communication/azure-communication-chat/env-test.properties
+++ b/sdk/communication/azure-communication-chat/env-test.properties
@@ -1,5 +1,5 @@
 trouter.client.version="99116/0.0.0.0/"
-trouter.max.registration.ttls="3600"
+trouter.max.registration.ttls="3601"
 platform="SPOOL"
 platform.ui.version="0.0.0.0"
 

--- a/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/ChatClientBuilder.java
+++ b/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/ChatClientBuilder.java
@@ -251,7 +251,7 @@ public final class ChatClientBuilder {
     }
 
     private void applyRequiredPolicies(List<HttpPipelinePolicy> policies, HttpPipelinePolicy authorizationPolicy) {
-        policies.add(new UserAgentPolicy(null, "azure-communication-chat", "1.0.0"));
+        policies.add(new UserAgentPolicy(null, "azure-communication-chat", "1.0.1"));
         policies.add(retryPolicy == null ? RetryPolicy.withExponentialBackoff() : retryPolicy);
         policies.add(new CookiePolicy());
         policies.add(authorizationPolicy);

--- a/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/ChatThreadClientBuilder.java
+++ b/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/ChatThreadClientBuilder.java
@@ -273,7 +273,7 @@ public final class ChatThreadClientBuilder {
 
     private void applyRequiredPolicies(List<HttpPipelinePolicy> policies, HttpPipelinePolicy authorizationPolicy) {
         policies.add(
-            new UserAgentPolicy(null, "azure-communication-chat", "1.0.0"));
+            new UserAgentPolicy(null, "azure-communication-chat", "1.0.1"));
         policies.add(retryPolicy == null ? RetryPolicy.withExponentialBackoff() : retryPolicy);
         policies.add(new CookiePolicy());
         policies.add(authorizationPolicy);

--- a/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/implementation/signaling/CommunicationListener.java
+++ b/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/implementation/signaling/CommunicationListener.java
@@ -3,6 +3,8 @@
 
 package com.azure.android.communication.chat.implementation.signaling;
 
+import android.text.TextUtils;
+
 import com.azure.android.communication.chat.models.ChatEvent;
 import com.azure.android.communication.chat.models.ChatEventType;
 import com.azure.android.communication.chat.models.RealTimeNotificationCallback;
@@ -11,6 +13,8 @@ import com.microsoft.trouterclient.ITrouterConnectionInfo;
 import com.microsoft.trouterclient.ITrouterListener;
 import com.microsoft.trouterclient.ITrouterRequest;
 import com.microsoft.trouterclient.ITrouterResponse;
+
+import java.util.List;
 
 final class CommunicationListener implements ITrouterListener {
 
@@ -57,4 +61,15 @@ final class CommunicationListener implements ITrouterListener {
         logger.info(msg);
     }
 
+    @Override
+    public void onTrouterUserActivityStateAccepted(String correlationVector) {
+        final String msg = "onTrouterUserActivityStateAccepted(): correlationVector=" + correlationVector;
+        logger.info(msg);
+    }
+
+    @Override
+    public void onTrouterMessageLoss(List<String> flowTags) {
+        final String msg = "onTrouterMessageLoss(): flowTags=" + TextUtils.join(",", flowTags);
+        logger.info(msg);
+    }
 }

--- a/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/implementation/signaling/TrouterUtils.java
+++ b/sdk/communication/azure-communication-chat/src/main/java/com/azure/android/communication/chat/implementation/signaling/TrouterUtils.java
@@ -52,6 +52,8 @@ public final class TrouterUtils {
     private static final JacksonSerder JACKSON_SERDER = JacksonSerder.createDefault();
     private static final Pattern PATTERN = Pattern.compile("^\"*|\"*$");
 
+    public static final int MAX_TOKEN_FETCH_RETRY_COUNT = 3;
+
     /**
      * Mapping chat event id to trouter event id code
      */


### PR DESCRIPTION
Update trouter lib 0.0.1-beta.3 -> 0.1.1, which contains fix for unclosed registration renew timer
Update core lib 1.0.0-beta.6 -> 1.0.0-beta.7, which contains fix for UserAgent ApplicationId
Update Chat SDK version to release a hotfix patch