### PR TITLE
Updated Azure Core Logging's dependency on SLF4J from `slf4j-api` to `slf4j-android`.

### DIFF
--- a/sdk/core/azure-core-logging/build.gradle
+++ b/sdk/core/azure-core-logging/build.gradle
@@ -11,7 +11,7 @@ android {
 
 dependencies {
     // <!-- begin: implementation Dependencies -->
-    implementation "org.slf4j:slf4j-api:$slf4jApiVersion"
+    implementation "org.slf4j:slf4j-android:$slf4jApiVersion"
     // <!-- end: implementation Dependencies -->
 
     // <!-- begin: test Dependencies -->


### PR DESCRIPTION
`slf4j-android` _["is basically a (i) repackaging of the SLF4J API part, together with (ii) a very lightweight binding implementation that simply forwards all SLF4J log requests to the logger provided on the Google Android platform."](http://www.slf4j.org/android/)_ --SLF4J Android, Logger name mapping.

This package includes an important workaround for the `Log.isLoggable()` Android API, [which will throw](https://stackoverflow.com/a/28168739) if a given tag is longer than 23 characters in length for Android API levels <= 25 [[1]](https://issuetracker.google.com/issues/124593220) [[2]](https://github.com/mvysny/slf4j-handroid/issues/2).