### PR TITLE
Downgraded Jackson dependencies to `2.12.5`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ allprojects {
         appCompatVersion = "1.2.0"
         azureCommunicationCommonVersion = "1.0.1"
         azureCoreVersion = "1.0.0-beta.8"
-        jacksonVersion = "2.13.0"
+        jacksonVersion = "2.12.5" // Do not upgrade to 2.13, as it introduced using an API not available in javax.xml.stream:stax-api:1.0-2
         junitJupiterVersion = "5.7.2"
         mockitoVersion = "4.0.0"
         nimbusJoseJwtTestVersion = "9.15.2"
@@ -267,7 +267,7 @@ allprojects {
         orgtestngVersion = "7.4.0"
         powerMockVersion = "2.0.9"
         retroFutureVersion = "1.7.4"
-        staxApiVersion = "1.0-2"
+        staxApiVersion = "1.0-2" // Need this instead of using the JDK due to: https://stackoverflow.com/a/47371517/1473510
         slf4jApiVersion = "1.7.32"
         threeTenAbpVersion = "1.3.1"
         threeTenBpVersion = "1.5.1"

--- a/sdk/core/azure-core-jackson/CHANGELOG.md
+++ b/sdk/core/azure-core-jackson/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.0-beta.9 (Unreleased)
 
+### Other changes
+
+#### Dependency updates
+- Downgraded `jackson-dataformat-xml` dependency version to `2.12.5`.
+- Downgraded `jackson-datatype-jsr310` dependency version to `2.12.5`.
 
 ## 1.0.0-beta.8 (2021-10-08)
 


### PR DESCRIPTION
The latest version of `jackson-dataformat-xml` (`2.13.0`) introduced [a change](https://github.com/FasterXML/jackson-dataformat-xml/pull/480) that replaces the use of `newInstance()` with `newFactory()` in the `XMLFactory` class. Unfortunately, this API is only available in the JDK's implementation of the `stax-api` library, which we cannot access in Android [[1]](https://stackoverflow.com/a/47371517/1473510), forcing us to use `javax.xml.stream:stax-api:1.0-2` instead. This causes a `ClassDefNotFound` exception when trying to do something like creating a new `ChatClient`, as reported by @CHILIU-MSFT.

![image](https://user-images.githubusercontent.com/5799331/138896189-257f2ba6-cabc-487f-a3fd-a611fef3d301.png)

![image](https://user-images.githubusercontent.com/5799331/138896164-ca2e5bbd-faf6-4f6d-ac9c-f3b7a6a3548f.png)

Fortunately they seem to have changed this again for next release (`2.14.0`) but this means waiting until it comes out.