### PR TITLE
Use HttpClientProvider's Classloader when Searching for Implementation

### DIFF
--- a/sdk/core/azure-core-http/src/main/java/com/azure/android/core/http/implementation/HttpClientProviders.java
+++ b/sdk/core/azure-core-http/src/main/java/com/azure/android/core/http/implementation/HttpClientProviders.java
@@ -4,6 +4,7 @@ package com.azure.android.core.http.implementation;
 
 import com.azure.android.core.http.HttpClient;
 import com.azure.android.core.http.HttpClientProvider;
+import com.azure.android.core.logging.ClientLogger;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
@@ -19,12 +20,27 @@ public final class HttpClientProviders {
         + "dependencies, you have the choice of OkHttp or HttpUrlConnection implementations. Additionally, refer to "
         + "https://aka.ms/azsdk/java/docs/custom-httpclient to learn about writing your own implementation.";
 
+    private static final ClientLogger LOGGER = new ClientLogger(HttpClientProviders.class);
+
     static {
-        ServiceLoader<HttpClientProvider> serviceLoader = ServiceLoader.load(HttpClientProvider.class);
+        // Use as classloader to load provider-configuration files and provider classes the classloader
+        // that loaded this class. In most cases this will be the System classloader.
+        // But this choice here provides additional flexibility in managed environments that control
+        // classloading differently (OSGi, Spring and others) and don't/ depend on the
+        // System classloader to load HttpClientProvider classes.
+        ServiceLoader<HttpClientProvider> serviceLoader = ServiceLoader.load(HttpClientProvider.class,
+            HttpClientProviders.class.getClassLoader());
         // Use the first provider found in the service loader iterator.
         Iterator<HttpClientProvider> it = serviceLoader.iterator();
         if (it.hasNext()) {
             defaultProvider = it.next();
+            LOGGER.verbose("Using {} as the default HttpClientProvider.", defaultProvider.getClass().getName());
+        }
+
+        while (it.hasNext()) {
+            HttpClientProvider ignoredProvider = it.next();
+            LOGGER.warning("Multiple HttpClientProviders were found on the classpath, ignoring {}.",
+                ignoredProvider.getClass().getName());
         }
     }
 
@@ -34,7 +50,7 @@ public final class HttpClientProviders {
 
     public static HttpClient createInstance() {
         if (defaultProvider == null) {
-            throw new IllegalStateException(CANNOT_FIND_HTTP_CLIENT);
+            throw LOGGER.logExceptionAsError(new IllegalStateException(CANNOT_FIND_HTTP_CLIENT));
         }
         return defaultProvider.createInstance();
     }


### PR DESCRIPTION
This PR updates the loading of service provider implementations to use the classloader that loaded the interface. The change corresponds to [this PR](https://github.com/Azure/azure-sdk-for-java/pull/20760) that was submitted to the azure-sdk-for-java repository to resolve an SPI loading issue when the default system classloader isn't capable of resolving an implementation that should be available.