### PR TITLE
Updated Jackson version to 2.12.6 in all modules.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ allprojects {
         appCompatVersion = "1.2.0"
         azureCommunicationCommonVersion = "1.0.1"
         azureCoreVersion = "1.0.0-beta.9"
-        jacksonVersion = "2.12.5" // Do not upgrade to 2.13, as it introduced using an API not available in javax.xml.stream:stax-api:1.0-2
+        jacksonVersion = "2.12.6" // Do not upgrade to 2.13, as it introduced using an API not available in javax.xml.stream:stax-api:1.0-2
         junitJupiterVersion = "5.7.2"
         mockitoVersion = "4.0.0"
         nimbusJoseJwtTestVersion = "9.15.2"

--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ allprojects {
         appCompatVersion = "1.2.0"
         azureCommunicationCommonVersion = "1.0.1"
         azureCoreVersion = "1.0.0-beta.9"
-        jacksonVersion = "2.12.6" // Do not upgrade to 2.13, as it introduced using an API not available in javax.xml.stream:stax-api:1.0-2
+        jacksonVersion = "2.12.6" // Do not upgrade to 2.13, as it introduced using an API not available in javax.xml.stream:stax-api:1.0-2. See: https://github.com/Azure/azure-sdk-for-android/issues/1017
         junitJupiterVersion = "5.7.2"
         mockitoVersion = "4.0.0"
         nimbusJoseJwtTestVersion = "9.15.2"

--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release History
 ## 1.1.0-beta.1 (Unreleased)
 
+### Other updates
+
+#### Dependency updates
+- Updated `jackson-databind` dependency to `2.12.6`
+
 ## 1.0.1 (2021-06-15)
 ### Dependency Updates
 - Updated `com.azure.android.core` from `1.0.0-beta.5` to `1.0.0-beta.6`

--- a/sdk/core/azure-core-jackson/CHANGELOG.md
+++ b/sdk/core/azure-core-jackson/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0-beta.9 (Unreleased)
+
+### Other changes
+
+#### Dependency updates
+- Updated `jackson-dataformat-xml` dependency to `2.12.6`.
+- Updated `jackson-datatype-jsr310` dependency to `2.12.6`.
+
 ## 1.0.0-beta.9 (2021-11-08)
 
 ### Other changes

--- a/sdk/core/azure-core-test/CHANGELOG.md
+++ b/sdk/core/azure-core-test/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0-beta.9 (Unreleased)
+
+### Other changes
+
+#### Dependency updates
+- Updated `jackson-databind` dependency to `2.12.6`.
+- Updated `jackson-dataformat-xml` dependency to `2.12.6`.
+
 ## 1.0.0-beta.9 (2021-11-08)
 
 ### Other changes


### PR DESCRIPTION
Cannot upgrade to `2.13+` because of #1017, so we are upgrading to the latest version below.