### PR TITLE
[CommunicationIdentifier] Added support for rawId ⟷ CommunicationIdentifier conversion

### DIFF
--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## 1.1.0-beta.1 (Unreleased)
+- Added `String getRawId()` and `static CommunicationIdentifier fromRawId(String rawId)` to `CommunicationIdentifier` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
 
 ### Features Added
 

--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.1.0-beta.1 (Unreleased)
-- Added `String getRawId()` and `static CommunicationIdentifier fromRawId(String rawId)` to `CommunicationIdentifier` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
+- Added `String getRawId()`, and `static CommunicationIdentifier fromRawId(String rawId)` to `CommunicationIdentifier` to translate between a `CommunicationIdentifier` and its underlying canonical rawId representation. Developers can now use the rawId as an encoded format for identifiers to store in their databases or as stable keys in general.
 
 ### Features Added
 

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -6,4 +6,72 @@ package com.azure.android.communication.common;
  * Common communication identifier for Communication Services
  */
 public abstract class CommunicationIdentifier {
+    protected String rawId;
+
+    /**
+     * When storing rawIds, use this function to restore the identifier that was encoded in the rawId.
+     *
+     * @param rawId raw id.
+     * @return CommunicationIdentifier
+     * @throws IllegalArgumentException raw id is null or empty.
+     */
+    public static CommunicationIdentifier fromRawId(String rawId) {
+        if (rawId == null || rawId.trim().length() == 0) {
+            throw new IllegalArgumentException("The parameter [rawId] cannot be null to empty.");
+        }
+
+        if (rawId.startsWith("4:")) {
+            return new PhoneNumberIdentifier("+" + rawId.substring("4:".length()));
+        }
+        final String[] segments = rawId.split(":");
+        if (segments.length < 3) {
+            return new UnknownIdentifier(rawId);
+        }
+
+        final String prefix = segments[0] + ":" + segments[1] + ":";
+        final String suffix = rawId.substring(prefix.length());
+
+        if ("8:teamsvisitor:".equals(prefix)) {
+            return new MicrosoftTeamsUserIdentifier(suffix, true);
+        } else if ("8:orgid:".equals(prefix)) {
+            return new MicrosoftTeamsUserIdentifier(suffix, false);
+        } else if ("8:dod:".equals(prefix)) {
+            return new MicrosoftTeamsUserIdentifier(suffix, false).setCloudEnvironment(CommunicationCloudEnvironment.DOD);
+        } else if ("8:gcch:".equals(prefix)) {
+            return new MicrosoftTeamsUserIdentifier(suffix, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
+        } else if ("8:acs:".equals(prefix) || "8:spool:".equals(prefix) || "8:dod-acs:".equals(prefix) || "8:gcch-acs:".equals(prefix)) {
+            return new CommunicationUserIdentifier(rawId);
+        }
+
+        return new UnknownIdentifier(rawId);
+    }
+
+    /**
+     * Returns the rawId for a given CommunicationIdentifier.
+     * You can use the rawId for encoding the identifier and then use it as a key in a database.
+     *
+     * @return raw id
+     */
+    public String getRawId() {
+        return rawId;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (!(that instanceof CommunicationIdentifier)) {
+            return false;
+        }
+
+        CommunicationIdentifier thatId = (CommunicationIdentifier) that;
+        return this.getRawId().equals(thatId.getRawId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getRawId().hashCode();
+    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -36,10 +36,13 @@ public abstract class CommunicationIdentifier {
         } else if ("8:orgid:".equals(prefix)) {
             return new MicrosoftTeamsUserIdentifier(suffix, false);
         } else if ("8:dod:".equals(prefix)) {
-            return new MicrosoftTeamsUserIdentifier(suffix, false).setCloudEnvironment(CommunicationCloudEnvironment.DOD);
+            return new MicrosoftTeamsUserIdentifier(suffix, false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
         } else if ("8:gcch:".equals(prefix)) {
-            return new MicrosoftTeamsUserIdentifier(suffix, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
-        } else if ("8:acs:".equals(prefix) || "8:spool:".equals(prefix) || "8:dod-acs:".equals(prefix) || "8:gcch-acs:".equals(prefix)) {
+            return new MicrosoftTeamsUserIdentifier(suffix, false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
+        } else if ("8:acs:".equals(prefix) || "8:spool:".equals(prefix)
+            || "8:dod-acs:".equals(prefix) || "8:gcch-acs:".equals(prefix)) {
             return new CommunicationUserIdentifier(rawId);
         }
 

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationUserIdentifier.java
@@ -43,9 +43,4 @@ public final class CommunicationUserIdentifier extends CommunicationIdentifier {
 
         return ((CommunicationUserIdentifier) that).getRawId().equals(getRawId());
     }
-
-    @Override
-    public int hashCode() {
-        return getRawId().hashCode();
-    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationUserIdentifier.java
@@ -19,6 +19,7 @@ public final class CommunicationUserIdentifier extends CommunicationIdentifier {
             throw new IllegalArgumentException("The initialization parameter [id] cannot be null or empty.");
         }
         this.id = id;
+        this.rawId = id;
     }
 
     /**
@@ -40,11 +41,11 @@ public final class CommunicationUserIdentifier extends CommunicationIdentifier {
             return false;
         }
 
-        return ((CommunicationUserIdentifier) that).getId().equals(id);
+        return ((CommunicationUserIdentifier) that).getRawId().equals(getRawId());
     }
 
     @Override
     public int hashCode() {
-        return getId().hashCode();
+        return getRawId().hashCode();
     }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationUserIdentifier.java
@@ -43,4 +43,9 @@ public final class CommunicationUserIdentifier extends CommunicationIdentifier {
 
         return ((CommunicationUserIdentifier) that).getRawId().equals(getRawId());
     }
+
+    @Override
+    public int hashCode() {
+        return getRawId().hashCode();
+    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -9,6 +9,7 @@ package com.azure.android.communication.common;
 public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier {
     private final String userId;
     private final boolean isAnonymous;
+    private boolean rawIdSet = false;
     private CommunicationCloudEnvironment cloudEnvironment = CommunicationCloudEnvironment.PUBLIC;
 
     /**
@@ -82,6 +83,7 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
      */
     public MicrosoftTeamsUserIdentifier setRawId(String rawId) {
         this.rawId = rawId;
+        rawIdSet = true;
         return this;
     }
 
@@ -117,14 +119,16 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
     }
 
     private void setRawId() {
-        if (this.isAnonymous) {
-            this.rawId = "8:teamsvisitor:" + this.userId;
-        } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-            this.rawId = "8:dod:" + this.userId;
-        } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-            this.rawId = "8:gcch:" + this.userId;
-        } else {
-            this.rawId = "8:orgid:" + this.userId;
+        if (!rawIdSet) {
+            if (this.isAnonymous) {
+                this.rawId = "8:teamsvisitor:" + this.userId;
+            } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
+                this.rawId = "8:dod:" + this.userId;
+            } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
+                this.rawId = "8:gcch:" + this.userId;
+            } else {
+                this.rawId = "8:orgid:" + this.userId;
+            }
         }
     }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -27,7 +27,7 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
         }
         this.userId = userId;
         this.isAnonymous = isAnonymous;
-        setRawId();
+        generateRawId();
     }
 
     /**
@@ -64,7 +64,7 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
      */
     public MicrosoftTeamsUserIdentifier setCloudEnvironment(CommunicationCloudEnvironment cloudEnvironment) {
         this.cloudEnvironment = cloudEnvironment;
-        setRawId();
+        generateRawId();
         return this;
     }
 
@@ -118,7 +118,7 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
         return getRawId().hashCode();
     }
 
-    private void setRawId() {
+    private void generateRawId() {
         if (!rawIdSet) {
             if (this.isAnonymous) {
                 this.rawId = "8:teamsvisitor:" + this.userId;

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -112,6 +112,12 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
             || thatId.getRawId().equals(this.getRawId());
     }
 
+
+    @Override
+    public int hashCode() {
+        return getRawId().hashCode();
+    }
+
     private void generateRawId() {
         if (!rawIdSet) {
             if (this.isAnonymous) {

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -112,12 +112,6 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
             || thatId.getRawId().equals(this.getRawId());
     }
 
-
-    @Override
-    public int hashCode() {
-        return getRawId().hashCode();
-    }
-
     private void generateRawId() {
         if (!rawIdSet) {
             if (this.isAnonymous) {

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -119,9 +119,9 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
     private void setRawId() {
         if (this.isAnonymous) {
             this.rawId = "8:teamsvisitor:" + this.userId;
-        } else if (cloudEnvironment == CommunicationCloudEnvironment.DOD) {
+        } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
             this.rawId = "8:dod:" + this.userId;
-        } else if (cloudEnvironment == CommunicationCloudEnvironment.GCCH) {
+        } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
             this.rawId = "8:gcch:" + this.userId;
         } else {
             this.rawId = "8:orgid:" + this.userId;

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -11,8 +11,6 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
     private final boolean isAnonymous;
     private CommunicationCloudEnvironment cloudEnvironment = CommunicationCloudEnvironment.PUBLIC;
 
-    private String rawId;
-
     /**
      * Creates a MicrosoftTeamsUserIdentifier object
      *
@@ -28,6 +26,7 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
         }
         this.userId = userId;
         this.isAnonymous = isAnonymous;
+        setRawId();
     }
 
     /**
@@ -64,6 +63,7 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
      */
     public MicrosoftTeamsUserIdentifier setCloudEnvironment(CommunicationCloudEnvironment cloudEnvironment) {
         this.cloudEnvironment = cloudEnvironment;
+        setRawId();
         return this;
     }
 
@@ -73,14 +73,6 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
      */
     public CommunicationCloudEnvironment getCloudEnvironment() {
         return cloudEnvironment;
-    }
-
-    /**
-     * Get full id of the identifier. This id is optional.
-     * @return full id of the identifier
-     */
-    public String getRawId() {
-        return rawId;
     }
 
     /**
@@ -104,10 +96,6 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
         }
 
         MicrosoftTeamsUserIdentifier thatId = (MicrosoftTeamsUserIdentifier) that;
-        if (!thatId.getUserId().equals(this.getUserId())
-            || thatId.isAnonymous != this.isAnonymous) {
-            return false;
-        }
 
         if (cloudEnvironment != null && !cloudEnvironment.equals(thatId.cloudEnvironment)) {
             return false;
@@ -125,6 +113,18 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
 
     @Override
     public int hashCode() {
-        return userId.hashCode();
+        return getRawId().hashCode();
+    }
+
+    private void setRawId() {
+        if (this.isAnonymous) {
+            this.rawId = "8:teamsvisitor:" + this.userId;
+        } else if (cloudEnvironment == CommunicationCloudEnvironment.DOD) {
+            this.rawId = "8:dod:" + this.userId;
+        } else if (cloudEnvironment == CommunicationCloudEnvironment.GCCH) {
+            this.rawId = "8:gcch:" + this.userId;
+        } else {
+            this.rawId = "8:orgid:" + this.userId;
+        }
     }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
@@ -56,9 +56,4 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
             || phoneId.getRawId() == null
             || getRawId().equals(phoneId.getRawId());
     }
-
-    @Override
-    public int hashCode() {
-        return getRawId().hashCode();
-    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
@@ -56,4 +56,9 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
             || phoneId.getRawId() == null
             || getRawId().equals(phoneId.getRawId());
     }
+
+    @Override
+    public int hashCode() {
+        return getRawId().hashCode();
+    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
@@ -21,6 +21,7 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
             throw new IllegalArgumentException("The initialization parameter [phoneNumber] cannot be null to empty.");
         }
         this.phoneNumber = phoneNumber;
+        this.rawId = "4:" + phoneNumber.replaceAll("^[+]", "");
     }
 
     /**
@@ -28,14 +29,6 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
      */
     public String getPhoneNumber() {
         return phoneNumber;
-    }
-
-    /**
-     * Get full id of the identifier. This id is optional.
-     * @return full id of the identifier
-     */
-    public String getRawId() {
-        return rawId;
     }
 
     /**
@@ -59,9 +52,6 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
         }
 
         PhoneNumberIdentifier phoneId = (PhoneNumberIdentifier) that;
-        if (!phoneNumber.equals(phoneId.phoneNumber)) {
-            return false;
-        }
 
         return getRawId() == null
             || phoneId.getRawId() == null
@@ -70,6 +60,6 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
 
     @Override
     public int hashCode() {
-        return phoneNumber.hashCode();
+        return getRawId().hashCode();
     }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
@@ -7,7 +7,6 @@ package com.azure.android.communication.common;
  */
 public final class PhoneNumberIdentifier extends CommunicationIdentifier {
     private final String phoneNumber;
-    private String rawId;
 
     /**
      * Creates a PhoneNumberIdentifier object

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/UnknownIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/UnknownIdentifier.java
@@ -44,9 +44,4 @@ public final class UnknownIdentifier extends CommunicationIdentifier {
         UnknownIdentifier thatId = (UnknownIdentifier) that;
         return this.getRawId().equals(thatId.getRawId());
     }
-
-    @Override
-    public int hashCode() {
-        return getRawId().hashCode();
-    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/UnknownIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/UnknownIdentifier.java
@@ -44,4 +44,9 @@ public final class UnknownIdentifier extends CommunicationIdentifier {
         UnknownIdentifier thatId = (UnknownIdentifier) that;
         return this.getRawId().equals(thatId.getRawId());
     }
+
+    @Override
+    public int hashCode() {
+        return getRawId().hashCode();
+    }
 }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/UnknownIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/UnknownIdentifier.java
@@ -20,6 +20,7 @@ public final class UnknownIdentifier extends CommunicationIdentifier {
             throw new IllegalArgumentException("The initialization parameter [id] cannot be null or empty.");
         }
         this.id = id;
+        this.rawId = id;
     }
 
     /**
@@ -41,11 +42,11 @@ public final class UnknownIdentifier extends CommunicationIdentifier {
         }
 
         UnknownIdentifier thatId = (UnknownIdentifier) that;
-        return this.id.equals(thatId.id);
+        return this.getRawId().equals(thatId.getRawId());
     }
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return getRawId().hashCode();
     }
 }

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -23,13 +23,37 @@ public class CommunicationIdentifierTests {
         // Teams users
         assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true),
             new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true));
-        assertNotEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true).setRawId("Raw Id"),
-            new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true).setRawId("Another Raw Id"));
-
-        assertEquals(new MicrosoftTeamsUserIdentifier("override", true).setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"),
+        assertNotEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true)
+                .setRawId("Raw Id"),
+            new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true)
+                .setRawId("Another Raw Id"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("override", true)
+                .setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"),
             new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true));
         assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true),
             new MicrosoftTeamsUserIdentifier("override", true).setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH).setRawId("8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH).setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD).setRawId("8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD).setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  false),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setRawId("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
 
         // Phone numbers
         assertEquals(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -5,6 +5,7 @@ package com.azure.android.communication.common;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CommunicationIdentifierTests {
 
@@ -12,28 +13,105 @@ public class CommunicationIdentifierTests {
     final String fullId = "some lengthy id string";
 
     @Test
-    public void equalityOnlyTestRawIdIfPresentOnBothSide() {
-        assertEquals(new MicrosoftTeamsUserIdentifier(userId, true).setRawId(fullId),
-            new MicrosoftTeamsUserIdentifier(userId, true));
-        assertEquals(new MicrosoftTeamsUserIdentifier(userId, true),
-            new MicrosoftTeamsUserIdentifier(userId, true));
-        assertEquals(new MicrosoftTeamsUserIdentifier(userId, true),
-            new MicrosoftTeamsUserIdentifier(userId, true).setRawId(fullId));
-        assertNotEquals(new MicrosoftTeamsUserIdentifier(userId, true).setRawId(fullId),
-            new MicrosoftTeamsUserIdentifier(userId, true).setRawId("another id"));
-
-        assertEquals(new PhoneNumberIdentifier("+12223334444").setRawId(fullId),
-            new PhoneNumberIdentifier("+12223334444"));
-        assertEquals(new PhoneNumberIdentifier("+12223334444"), new PhoneNumberIdentifier("+12223334444"));
-        assertEquals(new PhoneNumberIdentifier("+12223334444"),
-            new PhoneNumberIdentifier("+12223334444").setRawId(fullId));
-        assertNotEquals(new PhoneNumberIdentifier("+12223334444").setRawId(fullId),
-            new PhoneNumberIdentifier("+12223334444").setRawId("another id"));
-    }
-
-    @Test
     public void defaultCloudIsPublicForMicrosoftTeamsUserIdentifier() {
         assertEquals(CommunicationCloudEnvironment.PUBLIC,
             new MicrosoftTeamsUserIdentifier(userId, true).setRawId(fullId).getCloudEnvironment());
+    }
+
+    @Test
+    public void rawIdTakesPrecedenceInEqualityCheck() {
+        // Teams users
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true),
+            new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true));
+        assertNotEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true).setRawId("Raw Id"),
+            new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true).setRawId("Another Raw Id"));
+
+        assertEquals(new MicrosoftTeamsUserIdentifier("override", true).setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"),
+            new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true),
+            new MicrosoftTeamsUserIdentifier("override", true).setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+
+        // Phone numbers
+        assertEquals(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));
+        assertNotEquals(new PhoneNumberIdentifier("+14255550123").setRawId("Raw Id"),
+            new PhoneNumberIdentifier("+14255550123").setRawId("Another Raw Id"));
+
+        assertEquals(new PhoneNumberIdentifier("+override").setRawId("4:14255550123"),
+            new PhoneNumberIdentifier("+14255550123"));
+        assertEquals(new PhoneNumberIdentifier("+14255550123"),
+            new PhoneNumberIdentifier("+override").setRawId("4:14255550123"));
+    }
+
+    @Test
+    public void getRawIdOfIdentifier()
+    {
+        assertRawId(new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new CommunicationUserIdentifier("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new CommunicationUserIdentifier("someFutureFormat"), "someFutureFormat");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130"), "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130").setCloudEnvironment(CommunicationCloudEnvironment.DOD), "8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130").setCloudEnvironment(CommunicationCloudEnvironment.GCCH), "8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  false), "8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true), "8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true).setRawId("8:orgid:legacyFormat"), "8:orgid:legacyFormat");
+        assertRawId(new PhoneNumberIdentifier("+112345556789"), "4:112345556789");
+        assertRawId(new PhoneNumberIdentifier("+112345556789").setRawId("4:otherFormat"), "4:otherFormat");
+        assertRawId(new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"), "28:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRawId(new UnknownIdentifier("someFutureFormat"), "someFutureFormat");
+    }
+
+    @Test
+    public void createIdentifierFromRawId()
+    {
+        assertIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130", new CommunicationUserIdentifier("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertIdentifier("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130", new CommunicationUserIdentifier("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertIdentifier("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130", new CommunicationUserIdentifier("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertIdentifier("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130", new CommunicationUserIdentifier("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertIdentifier("8:acs:something", new CommunicationUserIdentifier("8:acs:something"));
+        assertIdentifier("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", false).setCloudEnvironment(CommunicationCloudEnvironment.PUBLIC));
+        assertIdentifier("8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", false).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
+        assertIdentifier("8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
+        assertIdentifier("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true).setCloudEnvironment(CommunicationCloudEnvironment.PUBLIC));
+        assertIdentifier("8:orgid:legacyFormat", new MicrosoftTeamsUserIdentifier("legacyFormat", false).setCloudEnvironment(CommunicationCloudEnvironment.PUBLIC));
+        assertIdentifier("4:112345556789", new PhoneNumberIdentifier("+112345556789"));
+        assertIdentifier("4:otherFormat", new PhoneNumberIdentifier("+otherFormat"));
+        assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+
+        final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
+        assertEquals("The parameter [rawId] cannot be null to empty.", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    public void rawIdStaysTheSameAfterConversionToIdentifierAndBack()
+    {
+        assertRoundTrip("8:acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:spool:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:dod-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:gcch-acs:bbbcbc1e-9f06-482a-b5d8-20e3f26ef0cd_45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:acs:something");
+        assertRoundTrip("8:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:dod:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("8:orgid:legacyFormat");
+        assertRoundTrip("4:112345556789");
+        assertRoundTrip("4:otherFormat");
+        assertRoundTrip("28:45ab2481-1c1c-4005-be24-0ffb879b1130");
+    }
+
+    private void assertRawId(CommunicationIdentifier identifier, String expectedRawId)  {
+        assertEquals(identifier.rawId, expectedRawId);
+    }
+
+    private void assertIdentifier(String rawId, CommunicationIdentifier expectedIdentifier)
+    {
+        assertEquals(CommunicationIdentifier.fromRawId(rawId), expectedIdentifier);
+        assertEquals(CommunicationIdentifier.fromRawId(rawId).hashCode(), expectedIdentifier.hashCode());
+    }
+
+    private void assertRoundTrip(String rawId)
+    {
+        assertEquals(CommunicationIdentifier.fromRawId(rawId).getRawId(), rawId);
     }
 }

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -54,6 +54,11 @@ public class CommunicationIdentifierTests {
         assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true),
             new MicrosoftTeamsUserIdentifier("override", false)
                 .setRawId("8:teamsvisitor:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130",  true)
+                .setRawId("test raw id")
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftTeamsUserIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH).setRawId("test raw id"));
 
         // Phone numbers
         assertEquals(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));


### PR DESCRIPTION
# Description

The `CommunicationIdentifier` design provides a good abstraction of Azure Communication Services internal id format with better type safety, auto-complete and hides internal knowledge.

However, it doesn't lend well to storing identifiers in a database or using them as keys because there is no clear canonical way how to encode them. This PR introduces translation functions that lets developers use the underlying raw ID for these purposes.

Details [Internal wiki](https://skype.visualstudio.com/SPOOL/_wiki/wikis/SPOOL.wiki/31075/Design-change-request-RawId-support-for-(de)serialization)

This PR closely follows the [Java  PR](https://github.com/Azure/azure-sdk-for-java/pull/28997).

No REST changes.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**

