### PR TITLE
Added null check for `httpResponse` in `RetryStrategy`.

### DIFF
--- a/sdk/core/azure-core-http/src/main/java/com/azure/android/core/http/policy/RetryStrategy.java
+++ b/sdk/core/azure-core-http/src/main/java/com/azure/android/core/http/policy/RetryStrategy.java
@@ -35,12 +35,16 @@ public interface RetryStrategy {
             return error instanceof IOException
                 || error instanceof TimeoutException;
         } else {
-            final int code = response.getStatusCode();
-            return (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT
-                || code == 429 // to-many requests
-                || (code >= HttpURLConnection.HTTP_INTERNAL_ERROR
-                && code != HttpURLConnection.HTTP_NOT_IMPLEMENTED
-                && code != HttpURLConnection.HTTP_VERSION));
+            if (response != null) {
+                final int code = response.getStatusCode();
+                return (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT
+                    || code == 429 // to-many requests
+                    || (code >= HttpURLConnection.HTTP_INTERNAL_ERROR
+                    && code != HttpURLConnection.HTTP_NOT_IMPLEMENTED
+                    && code != HttpURLConnection.HTTP_VERSION));
+            } else {
+                return true;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: #1176.

Adding a null check for the parameter `httpResponse` in `RetryStrategy.shouldRetry()`.