### PR TITLE
Add default .assets directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Default Assets restore directory
+.assets
+
 *.class
 
 # Mobile Tools for Java (J2ME)


### PR DESCRIPTION
The default assets restore is a `.assets` directory in the repository root. This directory needs to be ignored by each individual langue.