### PR TITLE
Revert "Update azure-sdk-build-tools Repository Resource Refs in Yaml files"

### DIFF
--- a/sdk/communication/ci.yml
+++ b/sdk/communication/ci.yml
@@ -5,7 +5,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/tags/azure-sdk-build-tools_20220920.1
+      ref: refs/tags/azure-sdk-build-tools_20211215.1
 
     - repository: azure-sdk-tools
       type: github

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -5,7 +5,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/tags/azure-sdk-build-tools_20220920.1
+      ref: refs/tags/azure-sdk-build-tools_20211215.1
 
     - repository: azure-sdk-tools
       type: github


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-android#1196

The android release pipeline depends on a template that was removed with this change so rolling back until we can get that converted.

For reference the work to convert was started with https://github.com/Azure/azure-sdk-for-android/pull/1057 but never got completed. 

The template we need is being referenced is https://github.com/Azure/azure-sdk-for-android/blob/main/eng/pipelines/templates/stages/archetype-android-release.yml#L123 `/tools/generic-blob-upload/publish-blobs.yml@azure-sdk-build-tools` 