### PR TITLE
Prepare ACS Common a minor release - 1.1.0

### DIFF
--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Release History
 
-## 1.1.0-beta.2 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 1.1.0 (2022-11-11)
 
 ### Bugs Fixed
 - Fixed the logic of `PhoneNumberIdentifier` to always maintain the original phone number string whether it included the leading + sign or not.
-
-### Other Changes
 
 #### Dependency updates
 - Updated `android-core` version to `1.0.0-beta.12`.

--- a/sdk/communication/azure-communication-common/README.md
+++ b/sdk/communication/azure-communication-common/README.md
@@ -20,7 +20,7 @@ This package contains common code for Azure Communication Service libraries.
   APIs that would require the Java 8+ API desugaring provided by Android Gradle plugin 4.0.0.
 
 ### Versions available
-The current version of this library is **1.0.2**.
+The current version of this library is **1.1.0**.
 
 ### Install the library
 To install the Azure client libraries for Android, add them as dependencies within your
@@ -36,13 +36,13 @@ Add an `implementation` configuration to the `dependencies` block of your app's 
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-common:1.0.2"
+    implementation "com.azure.android:azure-communication-common:1.1.0"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-common:1.0.2")
+    implementation("com.azure.android:azure-communication-common:1.1.0")
 }
 ```
 
@@ -53,7 +53,7 @@ To import the library into your project using the [Maven](https://maven.apache.o
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-common</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 

--- a/sdk/communication/azure-communication-common/gradle.properties
+++ b/sdk/communication/azure-communication-common/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1.0-beta.2
+version=1.1.0


### PR DESCRIPTION
azure-communication-common a minor release -  1.1.0

- `PhoneNumberIdentifier` bugfix
- dependency updates