### PR TITLE
Update prepare-pipelines.yml to use the new jobs-based template

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -1,7 +1,7 @@
 trigger: none
 
 extends:
-  template: /eng/common/pipelines/templates/steps/prepare-pipelines.yml
+  template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
   parameters:
     Repository: $(Build.Repository.Name)
     Prefix: android


### PR DESCRIPTION
## Context

This is an Azure SDK Engineering System Team PR, made to address failing [prepare-pipelines](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2179&_a=summary) pipeline, as explained in https://github.com/Azure/azure-sdk-tools/issues/4888. The issue is currently mitigated with a manual configuration override of the machine pool used. This PR is a proper fix.

This PR is a follow-up PR to https://github.com/Azure/azure-sdk-tools/pull/4930.

## Changes made

This PR rewires `prepare-pipelines.yml` to use the new template introduced by https://github.com/Azure/azure-sdk-tools/pull/4930. This template sets, via `pool` definition, the Ubuntu image used by the `prepare-pipelines` pipeline, thus properly addressing the issue. See that PR description for more context.

## Testing done

See section on testing in https://github.com/Azure/azure-sdk-tools/pull/4930