### PR TITLE
Update `CODEOWNERS` paths: fix invalid paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,17 @@
 # https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners
 
 ################
+# Orphaned paths
+################
+# As of 2/9/2023 these paths have no owners:
+
+# /**
+# /.run/
+# /.vscode/
+# /config/
+# /doc/
+
+################
 # Automation
 ################
 
@@ -36,5 +47,3 @@
 # Eng Sys
 ###########
 /eng/                                               @benbp @weshaggard
-
-/**/ci.yml                                          @benbp


### PR DESCRIPTION
As part of ongoing work of enabling wildcard support for `CODEOWNERS`:
- https://github.com/Azure/azure-sdk-tools/issues/2770
- https://github.com/Azure/azure-sdk-tools/pull/5088

and enabling stricter validation:
- https://github.com/Azure/azure-sdk-tools/issues/4859

this PR:
- fixes invalid paths, to match rules explained [here](https://github.com/Azure/azure-sdk/blob/main/docs/policies/opensource.md#codeowners);
- removes `/**/tests.yml` and `/**/ci.yml`, to avoid all build failure notifications being routed to it once we enable the new regex-based, wildcard-supporting `CODEOWNERS` matcher, per: https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397330147

Once this PR is merged, I will enable the new `CODEOWNERS` matcher, similar to how it was done for `net` repo by these two PRs:
- https://github.com/Azure/azure-sdk-tools/pull/5241
- https://github.com/Azure/azure-sdk-tools/pull/5240