### PR TITLE
[Android] Added support for MicrosoftBotIdentifier

### DIFF
--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Release History
 
-## 1.2.0-beta.1 (Unreleased)
+## 2.0.0-beta.1 (Unreleased)
 
 ### Features Added
 - Added support for a new communication identifier `MicrosoftBotIdentifier`.
 
 ### Breaking Changes
+- Introduction of `MicrosoftBotIdentifier` is a breaking change. It will affect code that relied on using `UnknownIdentifier` with a rawID starting with `28:`
 
 ### Bugs Fixed
 

--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0-beta.1 (Unreleased)
 
 ### Features Added
+- Added support for a new communication identifier `MicrosoftBotIdentifier`.
 
 ### Breaking Changes
 

--- a/sdk/communication/azure-communication-common/gradle.properties
+++ b/sdk/communication/azure-communication-common/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.0-beta.1
+version=2.0.0-beta.1

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -6,6 +6,20 @@ package com.azure.android.communication.common;
  * Common communication identifier for Communication Services
  */
 public abstract class CommunicationIdentifier {
+    private static final String ACS_USER_PREFIX = "8:acs:";
+    private static final String ACS_GCCH_USER_PREFIX = "8:gcch-acs:";
+    private static final String ACS_DOD_USER_PREFIX = "8:dod-acs:";
+    private static final String SPOOL_USER_PREFIX = "8:spool:";
+    protected static final String TEAMS_PUBLIC_USER_PREFIX = "8:orgid:";
+    protected static final String TEAMS_GCCH_USER_PREFIX = "8:gcch:";
+    protected static final String TEAMS_DOD_USER_PREFIX = "8:dod:";
+    protected static final String TEAMS_ANONYMOUS_USER_PREFIX = "8:teamsvisitor:";
+    private static final String BOT_PUBLIC_PREFIX = "28:orgid:";
+    private static final String BOT_DOD_PREFIX = "28:dod:";
+    private static final String BOT_DOD_GLOBAL_PREFIX = "28:dod-global:";
+    private static final String BOT_GCCH_PREFIX = "28:gcch";
+    private static final String BOT_GCCH_GLOBAL_PREFIX = "28:gcch-global:";
+    protected static final String PHONE_NUMBER_PREFIX = "4:";
     private String rawId;
 
     /**
@@ -20,8 +34,8 @@ public abstract class CommunicationIdentifier {
             throw new IllegalArgumentException("The parameter [rawId] cannot be null to empty.");
         }
 
-        if (rawId.startsWith("4:")) {
-            return new PhoneNumberIdentifier(rawId.substring("4:".length()));
+        if (rawId.startsWith(PHONE_NUMBER_PREFIX)) {
+            return new PhoneNumberIdentifier(rawId.substring(PHONE_NUMBER_PREFIX.length()));
         }
         final String[] segments = rawId.split(":");
         if (segments.length < 3) {
@@ -31,18 +45,18 @@ public abstract class CommunicationIdentifier {
         final String prefix = segments[0] + ":" + segments[1] + ":";
         final String suffix = rawId.substring(prefix.length());
 
-        if ("8:teamsvisitor:".equals(prefix)) {
+        if (TEAMS_ANONYMOUS_USER_PREFIX.equals(prefix)) {
             return new MicrosoftTeamsUserIdentifier(suffix, true);
-        } else if ("8:orgid:".equals(prefix)) {
+        } else if (TEAMS_PUBLIC_USER_PREFIX.equals(prefix)) {
             return new MicrosoftTeamsUserIdentifier(suffix, false);
-        } else if ("8:dod:".equals(prefix)) {
+        } else if (TEAMS_DOD_USER_PREFIX.equals(prefix)) {
             return new MicrosoftTeamsUserIdentifier(suffix, false)
                 .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
-        } else if ("8:gcch:".equals(prefix)) {
+        } else if (TEAMS_GCCH_USER_PREFIX.equals(prefix)) {
             return new MicrosoftTeamsUserIdentifier(suffix, false)
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
-        } else if ("8:acs:".equals(prefix) || "8:spool:".equals(prefix)
-            || "8:dod-acs:".equals(prefix) || "8:gcch-acs:".equals(prefix)) {
+        } else if (ACS_USER_PREFIX.equals(prefix) || SPOOL_USER_PREFIX.equals(prefix)
+            || ACS_DOD_USER_PREFIX.equals(prefix) || ACS_GCCH_USER_PREFIX.equals(prefix)) {
             return new CommunicationUserIdentifier(rawId);
         }
 

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -63,7 +63,7 @@ public abstract class CommunicationIdentifier {
             case BOT_DOD_CLOUD_GLOBAL_PREFIX:
                 return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.DOD, false);
             case BOT_GCCH_CLOUD_GLOBAL_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.GCCH,false);
+                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.GCCH, false);
             case BOT_PUBLIC_CLOUD_PREFIX:
                 return new MicrosoftBotIdentifier(suffix, true);
             case BOT_DOD_CLOUD_PREFIX:

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -7,20 +7,20 @@ package com.azure.android.communication.common;
  */
 public abstract class CommunicationIdentifier {
     static final String ACS_USER_PREFIX = "8:acs:";
-    static final String ACS_GCCH_USER_PREFIX = "8:gcch-acs:";
-    static final String ACS_DOD_USER_PREFIX = "8:dod-acs:";
+    static final String ACS_USER_GCCH_CLOUD_PREFIX = "8:gcch-acs:";
+    static final String ACS_USER_DOD_CLOUD_PREFIX = "8:dod-acs:";
     static final String SPOOL_USER_PREFIX = "8:spool:";
-    static final String TEAMS_PUBLIC_USER_PREFIX = "8:orgid:";
-    static final String TEAMS_GCCH_USER_PREFIX = "8:gcch:";
-    static final String TEAMS_DOD_USER_PREFIX = "8:dod:";
+    static final String TEAMS_USER_PUBLIC_CLOUD_PREFIX = "8:orgid:";
+    static final String TEAMS_USER_GCCH_CLOUD_PREFIX = "8:gcch:";
+    static final String TEAMS_USER_DOD_CLOUD_PREFIX = "8:dod:";
     static final String TEAMS_ANONYMOUS_USER_PREFIX = "8:teamsvisitor:";
-    static final String BOT_PUBLIC_PREFIX = "28:orgid:";
-    static final String BOT_DOD_PREFIX = "28:dod:";
-    static final String BOT_DOD_GLOBAL_PREFIX = "28:dod-global:";
-    static final String BOT_GCCH_PREFIX = "28:gcch:";
-    static final String BOT_GCCH_GLOBAL_PREFIX = "28:gcch-global:";
-    static final String PHONE_NUMBER_PREFIX = "4:";
     static final String BOT_PREFIX = "28:";
+    static final String BOT_PUBLIC_CLOUD_PREFIX = "28:orgid:";
+    static final String BOT_DOD_CLOUD_PREFIX = "28:dod:";
+    static final String BOT_DOD_CLOUD_GLOBAL_PREFIX = "28:dod-global:";
+    static final String BOT_GCCH_CLOUD_PREFIX = "28:gcch:";
+    static final String BOT_GCCH_CLOUD_GLOBAL_PREFIX = "28:gcch-global:";
+    static final String PHONE_NUMBER_PREFIX = "4:";
     private String rawId;
 
     /**
@@ -42,7 +42,7 @@ public abstract class CommunicationIdentifier {
         int segmentCount = segments.length;
         if (segmentCount != 3) {
             if (segmentCount == 2 && rawId.startsWith(BOT_PREFIX)) {
-                return new MicrosoftBotIdentifier(segments[1], true);
+                return new MicrosoftBotIdentifier(segments[1], false);
             }
             return new UnknownIdentifier(rawId);
         }
@@ -52,32 +52,28 @@ public abstract class CommunicationIdentifier {
         switch (prefix) {
             case TEAMS_ANONYMOUS_USER_PREFIX:
                 return new MicrosoftTeamsUserIdentifier(suffix, true);
-            case TEAMS_PUBLIC_USER_PREFIX:
+            case TEAMS_USER_PUBLIC_CLOUD_PREFIX:
                 return new MicrosoftTeamsUserIdentifier(suffix, false);
-            case TEAMS_DOD_USER_PREFIX:
+            case TEAMS_USER_DOD_CLOUD_PREFIX:
                 return new MicrosoftTeamsUserIdentifier(suffix, false)
                     .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
-            case TEAMS_GCCH_USER_PREFIX:
+            case TEAMS_USER_GCCH_CLOUD_PREFIX:
                 return new MicrosoftTeamsUserIdentifier(suffix, false)
                     .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
-            case BOT_DOD_GLOBAL_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, true)
-                    .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
-            case BOT_GCCH_GLOBAL_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, true)
-                    .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
-            case BOT_PUBLIC_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, false);
-            case BOT_DOD_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, false)
-                    .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
-            case BOT_GCCH_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, false)
-                    .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
+            case BOT_DOD_CLOUD_GLOBAL_PREFIX:
+                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.DOD, false);
+            case BOT_GCCH_CLOUD_GLOBAL_PREFIX:
+                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.GCCH,false);
+            case BOT_PUBLIC_CLOUD_PREFIX:
+                return new MicrosoftBotIdentifier(suffix, true);
+            case BOT_DOD_CLOUD_PREFIX:
+                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.DOD, true);
+            case BOT_GCCH_CLOUD_PREFIX:
+                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.GCCH, true);
             case ACS_USER_PREFIX:
             case SPOOL_USER_PREFIX:
-            case ACS_DOD_USER_PREFIX:
-            case ACS_GCCH_USER_PREFIX:
+            case ACS_USER_DOD_CLOUD_PREFIX:
+            case ACS_USER_GCCH_CLOUD_PREFIX:
                 return new CommunicationUserIdentifier(rawId);
             default:
                 return new UnknownIdentifier(rawId);

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -6,21 +6,21 @@ package com.azure.android.communication.common;
  * Common communication identifier for Communication Services
  */
 public abstract class CommunicationIdentifier {
-    private static final String ACS_USER_PREFIX = "8:acs:";
-    private static final String ACS_GCCH_USER_PREFIX = "8:gcch-acs:";
-    private static final String ACS_DOD_USER_PREFIX = "8:dod-acs:";
-    private static final String SPOOL_USER_PREFIX = "8:spool:";
-    protected static final String TEAMS_PUBLIC_USER_PREFIX = "8:orgid:";
-    protected static final String TEAMS_GCCH_USER_PREFIX = "8:gcch:";
-    protected static final String TEAMS_DOD_USER_PREFIX = "8:dod:";
-    protected static final String TEAMS_ANONYMOUS_USER_PREFIX = "8:teamsvisitor:";
-    protected static final String BOT_PUBLIC_PREFIX = "28:orgid:";
-    protected static final String BOT_DOD_PREFIX = "28:dod:";
-    protected static final String BOT_DOD_GLOBAL_PREFIX = "28:dod-global:";
-    protected static final String BOT_GCCH_PREFIX = "28:gcch";
-    protected static final String BOT_GCCH_GLOBAL_PREFIX = "28:gcch-global:";
-    protected static final String PHONE_NUMBER_PREFIX = "4:";
-    protected static final String BOT_PREFIX = "28:";
+    static final String ACS_USER_PREFIX = "8:acs:";
+    static final String ACS_GCCH_USER_PREFIX = "8:gcch-acs:";
+    static final String ACS_DOD_USER_PREFIX = "8:dod-acs:";
+    static final String SPOOL_USER_PREFIX = "8:spool:";
+    static final String TEAMS_PUBLIC_USER_PREFIX = "8:orgid:";
+    static final String TEAMS_GCCH_USER_PREFIX = "8:gcch:";
+    static final String TEAMS_DOD_USER_PREFIX = "8:dod:";
+    static final String TEAMS_ANONYMOUS_USER_PREFIX = "8:teamsvisitor:";
+    static final String BOT_PUBLIC_PREFIX = "28:orgid:";
+    static final String BOT_DOD_PREFIX = "28:dod:";
+    static final String BOT_DOD_GLOBAL_PREFIX = "28:dod-global:";
+    static final String BOT_GCCH_PREFIX = "28:gcch:";
+    static final String BOT_GCCH_GLOBAL_PREFIX = "28:gcch-global:";
+    static final String PHONE_NUMBER_PREFIX = "4:";
+    static final String BOT_PREFIX = "28:";
     private String rawId;
 
     /**

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -61,15 +61,15 @@ public abstract class CommunicationIdentifier {
                 return new MicrosoftTeamsUserIdentifier(suffix, false)
                     .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
             case BOT_DOD_CLOUD_GLOBAL_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.DOD, false);
+                return new MicrosoftBotIdentifier(suffix, false, CommunicationCloudEnvironment.DOD);
             case BOT_GCCH_CLOUD_GLOBAL_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.GCCH, false);
+                return new MicrosoftBotIdentifier(suffix, false, CommunicationCloudEnvironment.GCCH);
             case BOT_PUBLIC_CLOUD_PREFIX:
                 return new MicrosoftBotIdentifier(suffix, true);
             case BOT_DOD_CLOUD_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.DOD, true);
+                return new MicrosoftBotIdentifier(suffix, true, CommunicationCloudEnvironment.DOD);
             case BOT_GCCH_CLOUD_PREFIX:
-                return new MicrosoftBotIdentifier(suffix, CommunicationCloudEnvironment.GCCH, true);
+                return new MicrosoftBotIdentifier(suffix, true, CommunicationCloudEnvironment.GCCH);
             case ACS_USER_PREFIX:
             case SPOOL_USER_PREFIX:
             case ACS_USER_DOD_CLOUD_PREFIX:

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -39,8 +39,9 @@ public abstract class CommunicationIdentifier {
             return new PhoneNumberIdentifier(rawId.substring(PHONE_NUMBER_PREFIX.length()));
         }
         final String[] segments = rawId.split(":");
-        if (segments.length < 3) {
-            if (segments.length == 2 && rawId.startsWith(BOT_PREFIX)) {
+        int segmentCount = segments.length;
+        if (segmentCount != 3) {
+            if (segmentCount == 2 && rawId.startsWith(BOT_PREFIX)) {
                 return new MicrosoftBotIdentifier(segments[1], true);
             }
             return new UnknownIdentifier(rawId);

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/CommunicationIdentifier.java
@@ -55,9 +55,11 @@ public abstract class CommunicationIdentifier {
             case TEAMS_PUBLIC_USER_PREFIX:
                 return new MicrosoftTeamsUserIdentifier(suffix, false);
             case TEAMS_DOD_USER_PREFIX:
+                return new MicrosoftTeamsUserIdentifier(suffix, false)
+                    .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
             case TEAMS_GCCH_USER_PREFIX:
                 return new MicrosoftTeamsUserIdentifier(suffix, false)
-                    .setCloudEnvironment(CommunicationCloudEnvironment.fromString(segments[1]));
+                    .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
             case BOT_DOD_GLOBAL_PREFIX:
                 return new MicrosoftBotIdentifier(suffix, true)
                     .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
@@ -67,9 +69,11 @@ public abstract class CommunicationIdentifier {
             case BOT_PUBLIC_PREFIX:
                 return new MicrosoftBotIdentifier(suffix, false);
             case BOT_DOD_PREFIX:
+                return new MicrosoftBotIdentifier(suffix, false)
+                    .setCloudEnvironment(CommunicationCloudEnvironment.DOD);
             case BOT_GCCH_PREFIX:
                 return new MicrosoftBotIdentifier(suffix, false)
-                    .setCloudEnvironment(CommunicationCloudEnvironment.fromString(segments[1]));
+                    .setCloudEnvironment(CommunicationCloudEnvironment.GCCH);
             case ACS_USER_PREFIX:
             case SPOOL_USER_PREFIX:
             case ACS_DOD_USER_PREFIX:

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -4,7 +4,7 @@
 package com.azure.android.communication.common;
 
 /**
- * Communication identifier for Microsoft bots
+ * Communication identifier for a Microsoft bot.
  */
 public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     private final String botId;
@@ -73,7 +73,7 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     }
 
     /**
-     * Set full id of the identifier
+     * Set full id of the identifier.
      * RawId is the encoded format for identifiers to store in databases or as stable keys in general.
      *
      * @param rawId full id of the identifier.

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -10,17 +10,20 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     private final String botId;
     private final boolean isResourceAccountConfigured;
     private boolean rawIdSet = false;
-    private CommunicationCloudEnvironment cloudEnvironment;
+    private final CommunicationCloudEnvironment cloudEnvironment;
 
     /**
      * Creates a MicrosoftBotIdentifier object
      *
      * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
      * @param cloudEnvironment the cloud environment in which this identifier is created.
-     * @param isResourceAccountConfigured Set this to true if the bot is tenantized. It is false if the bot is global and no resource account is configured.
+     * @param isResourceAccountConfigured Set this to true if the bot is tenantized.
+     * It is false if the bot is global and no resource account is configured.
      * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
-    public MicrosoftBotIdentifier(String botId, CommunicationCloudEnvironment cloudEnvironment, boolean isResourceAccountConfigured) {
+    public MicrosoftBotIdentifier(String botId,
+                                  CommunicationCloudEnvironment cloudEnvironment,
+                                  boolean isResourceAccountConfigured) {
         if (botId == null || botId.trim().length() == 0) {
             throw new IllegalArgumentException("The initialization parameter [botId] cannot be null or empty.");
         }
@@ -34,7 +37,8 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
      * Creates a MicrosoftBotIdentifier object
      *
      * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
-     * @param isResourceAccountConfigured Set this to true if the bot is tenantized. It is false if the bot is global and no resource account is configured.
+     * @param isResourceAccountConfigured Set this to true if the bot is tenantized.
+     * It is false if the bot is global and no resource account is configured.
      * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
     public MicrosoftBotIdentifier(String botId, boolean isResourceAccountConfigured) {

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -8,23 +8,25 @@ package com.azure.android.communication.common;
  */
 public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     private final String botId;
-    private final boolean isGlobal;
+    private final boolean isResourceAccountConfigured;
     private boolean rawIdSet = false;
-    private CommunicationCloudEnvironment cloudEnvironment = CommunicationCloudEnvironment.PUBLIC;
+    private CommunicationCloudEnvironment cloudEnvironment;
 
     /**
      * Creates a MicrosoftBotIdentifier object
      *
      * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
-     * @param isGlobal Set this to true if the bot is global and false if the bot is tenantized.
-     * @throws IllegalArgumentException thrown if microsoftBotId parameter fail the validation.
+     * @param cloudEnvironment the cloud environment in which this identifier is created.
+     * @param isResourceAccountConfigured Set this to true if the bot is tenantized. It is false if the bot is global and no resource account is configured.
+     * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
-    public MicrosoftBotIdentifier(String botId, boolean isGlobal) {
+    public MicrosoftBotIdentifier(String botId, CommunicationCloudEnvironment cloudEnvironment, boolean isResourceAccountConfigured) {
         if (botId == null || botId.trim().length() == 0) {
             throw new IllegalArgumentException("The initialization parameter [botId] cannot be null or empty.");
         }
         this.botId = botId;
-        this.isGlobal = isGlobal;
+        this.cloudEnvironment = cloudEnvironment;
+        this.isResourceAccountConfigured = isResourceAccountConfigured;
         generateRawId();
     }
 
@@ -32,10 +34,21 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
      * Creates a MicrosoftBotIdentifier object
      *
      * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
-     * @throws IllegalArgumentException thrown if microsoftBotId parameter fail the validation.
+     * @param isResourceAccountConfigured Set this to true if the bot is tenantized. It is false if the bot is global and no resource account is configured.
+     * @throws IllegalArgumentException thrown if botId parameter fail the validation.
+     */
+    public MicrosoftBotIdentifier(String botId, boolean isResourceAccountConfigured) {
+        this(botId, CommunicationCloudEnvironment.PUBLIC, isResourceAccountConfigured);
+    }
+
+    /**
+     * Creates a MicrosoftBotIdentifier object
+     *
+     * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
+     * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
     public MicrosoftBotIdentifier(String botId) {
-        this(botId, false);
+        this(botId, CommunicationCloudEnvironment.PUBLIC, true);
     }
 
     /**
@@ -47,21 +60,10 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     }
 
     /**
-     * @return True if the bot is global and false if the bot is tenantized.
+     * @return True if the bot is tenantized and false if the bot is global and no resource account is configured.
      */
-    public boolean isGlobal() {
-        return this.isGlobal;
-    }
-
-    /**
-     * Set cloud environment of the Microsoft bot identifier, by default it is the Public cloud.
-     * @param cloudEnvironment the cloud environment in which this identifier is created.
-     * @return this object
-     */
-    public MicrosoftBotIdentifier setCloudEnvironment(CommunicationCloudEnvironment cloudEnvironment) {
-        this.cloudEnvironment = cloudEnvironment;
-        generateRawId();
-        return this;
+    public boolean isResourceAccountConfigured() {
+        return this.isResourceAccountConfigured;
     }
 
     /**
@@ -96,19 +98,7 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
             return false;
         }
 
-        MicrosoftBotIdentifier thatId = (MicrosoftBotIdentifier) that;
-
-        if (cloudEnvironment != null && !cloudEnvironment.equals(thatId.cloudEnvironment)) {
-            return false;
-        }
-
-        if (thatId.cloudEnvironment != null && !thatId.cloudEnvironment.equals(this.cloudEnvironment)) {
-            return false;
-        }
-
-        return getRawId() == null
-            || thatId.getRawId() == null
-            || thatId.getRawId().equals(this.getRawId());
+        return ((MicrosoftBotIdentifier) that).getRawId().equals(this.getRawId());
     }
 
 
@@ -119,21 +109,21 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
 
     private void generateRawId() {
         if (!rawIdSet) {
-            if (this.isGlobal) {
+            if (!this.isResourceAccountConfigured) {
                 if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                    super.setRawId(BOT_DOD_GLOBAL_PREFIX + this.botId);
+                    super.setRawId(BOT_DOD_CLOUD_GLOBAL_PREFIX + this.botId);
                 } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                    super.setRawId(BOT_GCCH_GLOBAL_PREFIX + this.botId);
+                    super.setRawId(BOT_GCCH_CLOUD_GLOBAL_PREFIX + this.botId);
                 } else {
                     super.setRawId(BOT_PREFIX + this.botId);
                 }
             } else {
                 if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                    super.setRawId(BOT_DOD_PREFIX + this.botId);
+                    super.setRawId(BOT_DOD_CLOUD_PREFIX + this.botId);
                 } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                    super.setRawId(BOT_GCCH_PREFIX + this.botId);
+                    super.setRawId(BOT_GCCH_CLOUD_PREFIX + this.botId);
                 } else {
-                    super.setRawId(BOT_PUBLIC_PREFIX + this.botId);
+                    super.setRawId(BOT_PUBLIC_CLOUD_PREFIX + this.botId);
                 }
             }
         }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.android.communication.common;
+
+/**
+ * Communication identifier for Microsoft bots
+ */
+public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
+    private final String microsoftBotId;
+    private final boolean isGlobal;
+    private boolean rawIdSet = false;
+    private CommunicationCloudEnvironment cloudEnvironment = CommunicationCloudEnvironment.PUBLIC;
+
+    /**
+     * Creates a MicrosoftBotIdentifier object
+     *
+     * @param microsoftBotId The unique Microsoft app ID for the bot as registered with the Bot Framework.
+     * @param isGlobal Set this to true if the bot is global and false if the bot is tenantized.
+     * @throws IllegalArgumentException thrown if microsoftBotId parameter fail the validation.
+     */
+    public MicrosoftBotIdentifier(String microsoftBotId, boolean isGlobal) {
+        if (microsoftBotId == null || microsoftBotId.trim().length() == 0) {
+            throw new IllegalArgumentException("The initialization parameter [microsoftBotId] cannot be null or empty.");
+        }
+        this.microsoftBotId = microsoftBotId;
+        this.isGlobal = isGlobal;
+        generateRawId();
+    }
+
+    /**
+     * Creates a MicrosoftBotIdentifier object
+     *
+     * @param microsoftBotId The unique Microsoft app ID for the bot as registered with the Bot Framework.
+     * @throws IllegalArgumentException thrown if microsoftBotId parameter fail the validation.
+     */
+    public MicrosoftBotIdentifier(String microsoftBotId) {
+        this(microsoftBotId, false);
+    }
+
+    /**
+     * Get the Microsoft app ID for the bot.
+     * @return microsoftBotId Id of the Microsoft app ID for the bot.
+     */
+    public String getMicrosoftBotId() {
+        return this.microsoftBotId;
+    }
+
+    /**
+     * @return True if the bot is global and false if the bot is tenantized.
+     */
+    public boolean isGlobal() {
+        return this.isGlobal;
+    }
+
+    /**
+     * Set cloud environment of the Microsoft bot identifier, by default it is the Public cloud.
+     * @param cloudEnvironment the cloud environment in which this identifier is created.
+     * @return this object
+     */
+    public MicrosoftBotIdentifier setCloudEnvironment(CommunicationCloudEnvironment cloudEnvironment) {
+        this.cloudEnvironment = cloudEnvironment;
+        generateRawId();
+        return this;
+    }
+
+    /**
+     * Get cloud environment of the Microsoft bot identifier.
+     * @return cloud environment in which this identifier is created.
+     */
+    public CommunicationCloudEnvironment getCloudEnvironment() {
+        return cloudEnvironment;
+    }
+
+    /**
+     * Set full id of the identifier
+     * RawId is the encoded format for identifiers to store in databases or as stable keys in general.
+     *
+     * @param rawId full id of the identifier.
+     * @return MicrosoftBotIdentifier object itself.
+     */
+    @Override
+    public MicrosoftBotIdentifier setRawId(String rawId) {
+        super.setRawId(rawId);
+        rawIdSet = true;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (!(that instanceof MicrosoftBotIdentifier)) {
+            return false;
+        }
+
+        MicrosoftBotIdentifier thatId = (MicrosoftBotIdentifier) that;
+
+        if (cloudEnvironment != null && !cloudEnvironment.equals(thatId.cloudEnvironment)) {
+            return false;
+        }
+
+        if (thatId.cloudEnvironment != null && !thatId.cloudEnvironment.equals(this.cloudEnvironment)) {
+            return false;
+        }
+
+        return getRawId() == null
+            || thatId.getRawId() == null
+            || thatId.getRawId().equals(this.getRawId());
+    }
+
+
+    @Override
+    public int hashCode() {
+        return getRawId().hashCode();
+    }
+
+    private void generateRawId() {
+        if (!rawIdSet) {
+            if (this.isGlobal) {
+                if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
+                    super.setRawId(BOT_DOD_GLOBAL_PREFIX + this.microsoftBotId);
+                } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
+                    super.setRawId(BOT_GCCH_GLOBAL_PREFIX + this.microsoftBotId);
+                } else {
+                    super.setRawId(BOT_PREFIX + this.microsoftBotId);
+                }
+            } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
+                super.setRawId(BOT_DOD_PREFIX + this.microsoftBotId);
+            } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
+                super.setRawId(BOT_GCCH_PREFIX + this.microsoftBotId);
+            } else {
+                super.setRawId(BOT_PUBLIC_PREFIX + this.microsoftBotId);
+            }
+        }
+    }
+}

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -7,7 +7,7 @@ package com.azure.android.communication.common;
  * Communication identifier for Microsoft bots
  */
 public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
-    private final String microsoftBotId;
+    private final String botId;
     private final boolean isGlobal;
     private boolean rawIdSet = false;
     private CommunicationCloudEnvironment cloudEnvironment = CommunicationCloudEnvironment.PUBLIC;
@@ -15,16 +15,15 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     /**
      * Creates a MicrosoftBotIdentifier object
      *
-     * @param microsoftBotId The unique Microsoft app ID for the bot as registered with the Bot Framework.
+     * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
      * @param isGlobal Set this to true if the bot is global and false if the bot is tenantized.
      * @throws IllegalArgumentException thrown if microsoftBotId parameter fail the validation.
      */
-    public MicrosoftBotIdentifier(String microsoftBotId, boolean isGlobal) {
-        if (microsoftBotId == null || microsoftBotId.trim().length() == 0) {
-            String error = "The initialization parameter [microsoftBotId] cannot be null or empty.";
-            throw new IllegalArgumentException(error);
+    public MicrosoftBotIdentifier(String botId, boolean isGlobal) {
+        if (botId == null || botId.trim().length() == 0) {
+            throw new IllegalArgumentException("The initialization parameter [botId] cannot be null or empty.");
         }
-        this.microsoftBotId = microsoftBotId;
+        this.botId = botId;
         this.isGlobal = isGlobal;
         generateRawId();
     }
@@ -32,19 +31,19 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
     /**
      * Creates a MicrosoftBotIdentifier object
      *
-     * @param microsoftBotId The unique Microsoft app ID for the bot as registered with the Bot Framework.
+     * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
      * @throws IllegalArgumentException thrown if microsoftBotId parameter fail the validation.
      */
-    public MicrosoftBotIdentifier(String microsoftBotId) {
-        this(microsoftBotId, false);
+    public MicrosoftBotIdentifier(String botId) {
+        this(botId, false);
     }
 
     /**
      * Get the Microsoft app ID for the bot.
      * @return microsoftBotId Id of the Microsoft app ID for the bot.
      */
-    public String getMicrosoftBotId() {
-        return this.microsoftBotId;
+    public String getBotId() {
+        return this.botId;
     }
 
     /**
@@ -122,19 +121,19 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
         if (!rawIdSet) {
             if (this.isGlobal) {
                 if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                    super.setRawId(BOT_DOD_GLOBAL_PREFIX + this.microsoftBotId);
+                    super.setRawId(BOT_DOD_GLOBAL_PREFIX + this.botId);
                 } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                    super.setRawId(BOT_GCCH_GLOBAL_PREFIX + this.microsoftBotId);
+                    super.setRawId(BOT_GCCH_GLOBAL_PREFIX + this.botId);
                 } else {
-                    super.setRawId(BOT_PREFIX + this.microsoftBotId);
+                    super.setRawId(BOT_PREFIX + this.botId);
                 }
             } else {
                 if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                    super.setRawId(BOT_DOD_PREFIX + this.microsoftBotId);
+                    super.setRawId(BOT_DOD_PREFIX + this.botId);
                 } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                    super.setRawId(BOT_GCCH_PREFIX + this.microsoftBotId);
+                    super.setRawId(BOT_GCCH_PREFIX + this.botId);
                 } else {
-                    super.setRawId(BOT_PUBLIC_PREFIX + this.microsoftBotId);
+                    super.setRawId(BOT_PUBLIC_PREFIX + this.botId);
                 }
             }
         }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -21,7 +21,8 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
      */
     public MicrosoftBotIdentifier(String microsoftBotId, boolean isGlobal) {
         if (microsoftBotId == null || microsoftBotId.trim().length() == 0) {
-            throw new IllegalArgumentException("The initialization parameter [microsoftBotId] cannot be null or empty.");
+            String error = "The initialization parameter [microsoftBotId] cannot be null or empty.";
+            throw new IllegalArgumentException(error);
         }
         this.microsoftBotId = microsoftBotId;
         this.isGlobal = isGlobal;

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -16,14 +16,14 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
      * Creates a MicrosoftBotIdentifier object
      *
      * @param botId The unique Microsoft app ID for the bot as registered with the Bot Framework.
-     * @param cloudEnvironment the cloud environment in which this identifier is created.
      * @param isResourceAccountConfigured Set this to true if the bot is tenantized.
      * It is false if the bot is global and no resource account is configured.
+     * @param cloudEnvironment the cloud environment in which this identifier is created.
      * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
     public MicrosoftBotIdentifier(String botId,
-                                  CommunicationCloudEnvironment cloudEnvironment,
-                                  boolean isResourceAccountConfigured) {
+                                  boolean isResourceAccountConfigured,
+                                  CommunicationCloudEnvironment cloudEnvironment) {
         if (botId == null || botId.trim().length() == 0) {
             throw new IllegalArgumentException("The initialization parameter [botId] cannot be null or empty.");
         }
@@ -42,7 +42,7 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
      * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
     public MicrosoftBotIdentifier(String botId, boolean isResourceAccountConfigured) {
-        this(botId, CommunicationCloudEnvironment.PUBLIC, isResourceAccountConfigured);
+        this(botId, isResourceAccountConfigured, CommunicationCloudEnvironment.PUBLIC);
     }
 
     /**
@@ -52,7 +52,7 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
      * @throws IllegalArgumentException thrown if botId parameter fail the validation.
      */
     public MicrosoftBotIdentifier(String botId) {
-        this(botId, CommunicationCloudEnvironment.PUBLIC, true);
+        this(botId, true, CommunicationCloudEnvironment.PUBLIC);
     }
 
     /**

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftBotIdentifier.java
@@ -127,12 +127,14 @@ public final class MicrosoftBotIdentifier extends CommunicationIdentifier {
                 } else {
                     super.setRawId(BOT_PREFIX + this.microsoftBotId);
                 }
-            } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                super.setRawId(BOT_DOD_PREFIX + this.microsoftBotId);
-            } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                super.setRawId(BOT_GCCH_PREFIX + this.microsoftBotId);
             } else {
-                super.setRawId(BOT_PUBLIC_PREFIX + this.microsoftBotId);
+                if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
+                    super.setRawId(BOT_DOD_PREFIX + this.microsoftBotId);
+                } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
+                    super.setRawId(BOT_GCCH_PREFIX + this.microsoftBotId);
+                } else {
+                    super.setRawId(BOT_PUBLIC_PREFIX + this.microsoftBotId);
+                }
             }
         }
     }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -126,11 +126,11 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
             if (this.isAnonymous) {
                 super.setRawId(TEAMS_ANONYMOUS_USER_PREFIX + this.userId);
             } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                super.setRawId(TEAMS_DOD_USER_PREFIX + this.userId);
+                super.setRawId(TEAMS_USER_DOD_CLOUD_PREFIX + this.userId);
             } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                super.setRawId(TEAMS_GCCH_USER_PREFIX + this.userId);
+                super.setRawId(TEAMS_USER_GCCH_CLOUD_PREFIX + this.userId);
             } else {
-                super.setRawId(TEAMS_PUBLIC_USER_PREFIX + this.userId);
+                super.setRawId(TEAMS_USER_PUBLIC_CLOUD_PREFIX + this.userId);
             }
         }
     }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/MicrosoftTeamsUserIdentifier.java
@@ -124,13 +124,13 @@ public final class MicrosoftTeamsUserIdentifier extends CommunicationIdentifier 
     private void generateRawId() {
         if (!rawIdSet) {
             if (this.isAnonymous) {
-                super.setRawId("8:teamsvisitor:" + this.userId);
+                super.setRawId(TEAMS_ANONYMOUS_USER_PREFIX + this.userId);
             } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.DOD)) {
-                super.setRawId("8:dod:" + this.userId);
+                super.setRawId(TEAMS_DOD_USER_PREFIX + this.userId);
             } else if (cloudEnvironment.equals(CommunicationCloudEnvironment.GCCH)) {
-                super.setRawId("8:gcch:" + this.userId);
+                super.setRawId(TEAMS_GCCH_USER_PREFIX + this.userId);
             } else {
-                super.setRawId("8:orgid:" + this.userId);
+                super.setRawId(TEAMS_PUBLIC_USER_PREFIX + this.userId);
             }
         }
     }

--- a/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
+++ b/sdk/communication/azure-communication-common/src/main/java/com/azure/android/communication/common/PhoneNumberIdentifier.java
@@ -20,7 +20,7 @@ public final class PhoneNumberIdentifier extends CommunicationIdentifier {
             throw new IllegalArgumentException("The initialization parameter [phoneNumber] cannot be null to empty.");
         }
         this.phoneNumber = phoneNumber;
-        this.setRawId("4:" + phoneNumber);
+        this.setRawId(PHONE_NUMBER_PREFIX + phoneNumber);
     }
 
     /**

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -4,9 +4,9 @@ package com.azure.android.communication.common;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CommunicationIdentifierTests {
 
@@ -43,74 +43,58 @@ public class CommunicationIdentifierTests {
 
     @Test
     public void microsoftBotIdentifier_defaultGlobalIsFalse() {
-        assertFalse((new MicrosoftBotIdentifier(userId)).isGlobal());
-        assertFalse((new MicrosoftBotIdentifier(userId)).setRawId(fullId).isGlobal());
+        assertTrue((new MicrosoftBotIdentifier(userId)).isResourceAccountConfigured());
+        assertTrue((new MicrosoftBotIdentifier(userId)).setRawId(fullId).isResourceAccountConfigured());
     }
 
     @Test
     public void microsoftBotIdentifier_rawIdTakesPrecedenceInEqualityCheck() {
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true),
-            new MicrosoftBotIdentifier(microsoftBotId, true));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false),
+            new MicrosoftBotIdentifier(microsoftBotId, false));
 
 
         String publicGlobalRawId = "28:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertNotEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
+        assertNotEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
                 .setRawId(publicGlobalRawId),
-            new MicrosoftBotIdentifier(microsoftBotId, true)
+            new MicrosoftBotIdentifier(microsoftBotId, false)
                 .setRawId("raw id"));
-        assertEquals(new MicrosoftBotIdentifier("override", true)
+        assertEquals(new MicrosoftBotIdentifier("override", false)
                 .setRawId(publicGlobalRawId),
-            new MicrosoftBotIdentifier(microsoftBotId, true));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true),
-            new MicrosoftBotIdentifier("override", false)
+            new MicrosoftBotIdentifier(microsoftBotId, false));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false),
+            new MicrosoftBotIdentifier("override", true)
                 .setRawId(publicGlobalRawId));
 
         String gcchGlobalRawId = "28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
-            new MicrosoftBotIdentifier("override", true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, false),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, false)
                 .setRawId(gcchGlobalRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
-            new MicrosoftBotIdentifier("override", false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, false),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, true)
                 .setRawId(gcchGlobalRawId));
 
         String gcchRawId = "28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
-            new MicrosoftBotIdentifier("override", true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, true),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, true)
                 .setRawId(gcchRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
-            new MicrosoftBotIdentifier("override", false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, true),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, false)
                 .setRawId(gcchRawId));
 
         String dodGlobalRawId = "28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
-            new MicrosoftBotIdentifier("override", true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, false),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, false)
                 .setRawId(dodGlobalRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
-            new MicrosoftBotIdentifier("override", false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, false),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, true)
                 .setRawId(dodGlobalRawId));
 
         String dodRawId = "28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
-            new MicrosoftBotIdentifier("override", true)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD,true),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, true)
                 .setRawId(dodRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
-            new MicrosoftBotIdentifier("override", false)
-                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, true),
+            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, false)
                 .setRawId(dodRawId));
     }
 
@@ -212,12 +196,12 @@ public class CommunicationIdentifierTests {
         assertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"));
         assertIdentifier("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"));
 
-        assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true));
-        assertIdentifier("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false));
-        assertIdentifier("28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
-        assertIdentifier("28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
-        assertIdentifier("28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
-        assertIdentifier("28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
+        assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false));
+        assertIdentifier("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true));
+        assertIdentifier("28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, true));
+        assertIdentifier("28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, false));
+        assertIdentifier("28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, true));
+        assertIdentifier("28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, false));
 
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
         assertEquals("The parameter [rawId] cannot be null to empty.", illegalArgumentException.getMessage());

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -66,35 +66,35 @@ public class CommunicationIdentifierTests {
                 .setRawId(publicGlobalRawId));
 
         String gcchGlobalRawId = "28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, false),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, false)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false, CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", false, CommunicationCloudEnvironment.GCCH)
                 .setRawId(gcchGlobalRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, false),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, true)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false, CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", true, CommunicationCloudEnvironment.GCCH)
                 .setRawId(gcchGlobalRawId));
 
         String gcchRawId = "28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, true),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, true)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true, CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", true, CommunicationCloudEnvironment.GCCH)
                 .setRawId(gcchRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, true),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.GCCH, false)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true, CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", false, CommunicationCloudEnvironment.GCCH)
                 .setRawId(gcchRawId));
 
         String dodGlobalRawId = "28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, false),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, false)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false, CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", false, CommunicationCloudEnvironment.DOD)
                 .setRawId(dodGlobalRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, false),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, true)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false, CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", true, CommunicationCloudEnvironment.DOD)
                 .setRawId(dodGlobalRawId));
 
         String dodRawId = "28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130";
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD,true),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, true)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId,true, CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", true, CommunicationCloudEnvironment.DOD)
                 .setRawId(dodRawId));
-        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, true),
-            new MicrosoftBotIdentifier("override", CommunicationCloudEnvironment.DOD, false)
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true, CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", false, CommunicationCloudEnvironment.DOD)
                 .setRawId(dodRawId));
     }
 
@@ -198,10 +198,10 @@ public class CommunicationIdentifierTests {
 
         assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false));
         assertIdentifier("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true));
-        assertIdentifier("28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, true));
-        assertIdentifier("28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.DOD, false));
-        assertIdentifier("28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, true));
-        assertIdentifier("28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, CommunicationCloudEnvironment.GCCH, false));
+        assertIdentifier("28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true, CommunicationCloudEnvironment.DOD));
+        assertIdentifier("28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false, CommunicationCloudEnvironment.DOD));
+        assertIdentifier("28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true, CommunicationCloudEnvironment.GCCH));
+        assertIdentifier("28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false, CommunicationCloudEnvironment.GCCH));
 
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
         assertEquals("The parameter [rawId] cannot be null to empty.", illegalArgumentException.getMessage());

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -113,7 +113,7 @@ public class CommunicationIdentifierTests {
         assertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768"));
         assertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"));
         assertIdentifier("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"));
-        assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"));
+        assertIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130", new UnknownIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130"));
 
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
         assertEquals("The parameter [rawId] cannot be null to empty.", illegalArgumentException.getMessage());

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -53,7 +53,7 @@ public class CommunicationIdentifierTests {
             new MicrosoftBotIdentifier(microsoftBotId, true));
 
 
-        String publicGlobalRawId = CommunicationIdentifier.BOT_PREFIX + microsoftBotId;
+        String publicGlobalRawId = "28:45ab2481-1c1c-4005-be24-0ffb879b1130";
         assertNotEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
                 .setRawId(publicGlobalRawId),
             new MicrosoftBotIdentifier(microsoftBotId, true)
@@ -65,7 +65,7 @@ public class CommunicationIdentifierTests {
             new MicrosoftBotIdentifier("override", false)
                 .setRawId(publicGlobalRawId));
 
-        String gcchGlobalRawId = CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + microsoftBotId;
+        String gcchGlobalRawId = "28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130";
         assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
             new MicrosoftBotIdentifier("override", true)
@@ -77,7 +77,7 @@ public class CommunicationIdentifierTests {
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
                 .setRawId(gcchGlobalRawId));
 
-        String gcchRawId = CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId;
+        String gcchRawId = "28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130";
         assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
             new MicrosoftBotIdentifier("override", true)
@@ -89,7 +89,7 @@ public class CommunicationIdentifierTests {
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
                 .setRawId(gcchRawId));
 
-        String dodGlobalRawId = CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId;
+        String dodGlobalRawId = "28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130";
         assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
                 .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
             new MicrosoftBotIdentifier("override", true)
@@ -101,7 +101,7 @@ public class CommunicationIdentifierTests {
                 .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
                 .setRawId(dodGlobalRawId));
 
-        String dodRawId = CommunicationIdentifier.BOT_DOD_PREFIX + microsoftBotId;
+        String dodRawId = "28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130";
         assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
                 .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
             new MicrosoftBotIdentifier("override", true)
@@ -212,12 +212,12 @@ public class CommunicationIdentifierTests {
         assertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"));
         assertIdentifier("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"));
 
-        assertIdentifier(CommunicationIdentifier.BOT_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true));
-        assertIdentifier(CommunicationIdentifier.BOT_PUBLIC_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false));
-        assertIdentifier(CommunicationIdentifier.BOT_DOD_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
-        assertIdentifier(CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
-        assertIdentifier(CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
-        assertIdentifier(CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
+        assertIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true));
+        assertIdentifier("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false));
+        assertIdentifier("28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
+        assertIdentifier("28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
+        assertIdentifier("28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
+        assertIdentifier("28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130", new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
 
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
         assertEquals("The parameter [rawId] cannot be null to empty.", illegalArgumentException.getMessage());
@@ -227,15 +227,15 @@ public class CommunicationIdentifierTests {
     public void createIdentifierFromRawId_unknownIdentifierForInvalidMRI() {
         String [] invalidRawIDs = {
             "48:45ab2481-1c1c-4005-be24-0ffb879b1130",
-            CommunicationIdentifier.BOT_PREFIX + microsoftBotId + ":newFormat",
-            CommunicationIdentifier.BOT_PUBLIC_PREFIX + microsoftBotId+ ":newFormat:with more segments",
-            CommunicationIdentifier.BOT_GCCH_PREFIX + ":abc-global:" + microsoftBotId,
-            CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + ":abc-global:" + microsoftBotId,
-            CommunicationIdentifier.ACS_GCCH_USER_PREFIX + ":abc:def:1234",
-            CommunicationIdentifier.ACS_USER_PREFIX + ":1:2:3:4:5:6:7:8:9",
-            CommunicationIdentifier.ACS_DOD_USER_PREFIX + ":1:2:3",
-            CommunicationIdentifier.SPOOL_USER_PREFIX + ": other format: :123: 90",
-            CommunicationIdentifier.TEAMS_PUBLIC_USER_PREFIX + ":abc:def:1234"
+            "28:45ab2481-1c1c-4005-be24-0ffb879b1130:newFormat",
+            "28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130:newFormat:with more segments",
+            "28:gcch:abc-global:45ab2481-1c1c-4005-be24-0ffb879b1130",
+            "28:gcch-global:abc-global:45ab2481-1c1c-4005-be24-0ffb879b1130",
+            "8:gcch-acs:abc:def:1234",
+            "8:acs::1:2:3:4:5:6:7:8:9",
+            "8:dod-acs::1:2:3",
+            "8:spool:: other format: :123: 90",
+            "8:orgid:abc:def:1234"
         };
         for (String invalidRawID: invalidRawIDs) {
             assertIdentifier(invalidRawID, new UnknownIdentifier(invalidRawID));
@@ -262,12 +262,12 @@ public class CommunicationIdentifierTests {
         assertRoundTrip("4:207ffef6-9444-41fb-92ab-20eacaae2768");
         assertRoundTrip("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768");
         assertRoundTrip("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768");
-        assertRoundTrip(CommunicationIdentifier.BOT_PREFIX + microsoftBotId);
-        assertRoundTrip(CommunicationIdentifier.BOT_PUBLIC_PREFIX + microsoftBotId);
-        assertRoundTrip(CommunicationIdentifier.BOT_DOD_PREFIX + microsoftBotId);
-        assertRoundTrip(CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId);
-        assertRoundTrip(CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId);
-        assertRoundTrip(CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId);
+        assertRoundTrip("28:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("28:orgid:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("28:dod:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("28:dod-global:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("28:gcch:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip("28:gcch-global:45ab2481-1c1c-4005-be24-0ffb879b1130");
     }
 
     private void assertRawId(CommunicationIdentifier identifier, String expectedRawId)  {

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -4,13 +4,15 @@ package com.azure.android.communication.common;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CommunicationIdentifierTests {
 
-    final String userId = "user id";
-    final String fullId = "some lengthy id string";
+    private final String userId = "user id";
+    private String microsoftBotId = "45ab2481-1c1c-4005-be24-0ffb879b1130";
+    private final String fullId = "some lengthy id string";
 
     @Test
     public void defaultCloudIsPublicForMicrosoftTeamsUserIdentifier() {
@@ -19,8 +21,101 @@ public class CommunicationIdentifierTests {
     }
 
     @Test
-    public void rawIdTakesPrecedenceInEqualityCheck() {
-        // Teams users
+    public void microsoftBotIdentifier_throwsMicrosoftBotIdNullOrEmpty() {
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new MicrosoftBotIdentifier(null));
+        assertEquals("The initialization parameter [microsoftBotId] cannot be null or empty.", illegalArgumentException.getMessage());
+
+        illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new MicrosoftBotIdentifier(""));
+        assertEquals("The initialization parameter [microsoftBotId] cannot be null or empty.", illegalArgumentException.getMessage());
+    }
+
+    @Test
+    public void microsoftBotIdentifier_defaultCloudIsPublic() {
+        assertEquals(CommunicationCloudEnvironment.PUBLIC,
+            new MicrosoftBotIdentifier(userId, true).setRawId(fullId).getCloudEnvironment());
+
+        assertEquals(CommunicationCloudEnvironment.PUBLIC,
+            new MicrosoftBotIdentifier(userId, false).setRawId(fullId).getCloudEnvironment());
+
+        assertEquals(CommunicationCloudEnvironment.PUBLIC,
+            new MicrosoftBotIdentifier(userId).setRawId(fullId).getCloudEnvironment());
+    }
+
+    @Test
+    public void microsoftBotIdentifier_defaultGlobalIsFalse() {
+        assertFalse((new MicrosoftBotIdentifier(userId)).isGlobal());
+        assertFalse((new MicrosoftBotIdentifier(userId)).setRawId(fullId).isGlobal());
+    }
+
+    @Test
+    public void microsoftBotIdentifier_rawIdTakesPrecedenceInEqualityCheck() {
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true),
+            new MicrosoftBotIdentifier(microsoftBotId, true));
+
+
+        String publicGlobalRawId = CommunicationIdentifier.BOT_PREFIX + microsoftBotId;
+        assertNotEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
+                .setRawId(publicGlobalRawId),
+            new MicrosoftBotIdentifier(microsoftBotId, true)
+                .setRawId("raw id"));
+        assertEquals(new MicrosoftBotIdentifier("override", true)
+                .setRawId(publicGlobalRawId),
+            new MicrosoftBotIdentifier(microsoftBotId, true));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true),
+            new MicrosoftBotIdentifier("override", false)
+                .setRawId(publicGlobalRawId));
+
+        String gcchGlobalRawId = CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + microsoftBotId;
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+                .setRawId(gcchGlobalRawId));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+                .setRawId(gcchGlobalRawId));
+
+        String gcchRawId = CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId;
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+                .setRawId(gcchRawId));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
+            new MicrosoftBotIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.GCCH)
+                .setRawId(gcchRawId));
+
+        String dodGlobalRawId = CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId;
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+                .setRawId(dodGlobalRawId));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+                .setRawId(dodGlobalRawId));
+
+        String dodRawId = CommunicationIdentifier.BOT_DOD_PREFIX + microsoftBotId;
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", true)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+                .setRawId(dodRawId));
+        assertEquals(new MicrosoftBotIdentifier(microsoftBotId, false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD),
+            new MicrosoftBotIdentifier("override", false)
+                .setCloudEnvironment(CommunicationCloudEnvironment.DOD)
+                .setRawId(dodRawId));
+    }
+
+    @Test
+    public void microsoftTeamsUserIdentifier_rawIdTakesPrecedenceInEqualityCheck() {
         assertEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true),
             new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true));
         assertNotEquals(new MicrosoftTeamsUserIdentifier("45ab2481-1c1c-4005-be24-0ffb879b1130", true)
@@ -59,8 +154,10 @@ public class CommunicationIdentifierTests {
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH),
             new MicrosoftTeamsUserIdentifier("override", false)
                 .setCloudEnvironment(CommunicationCloudEnvironment.GCCH).setRawId("test raw id"));
+    }
 
-        // Phone numbers
+    @Test
+    public void phoneNumberIdentifier_rawIdTakesPrecedenceInEqualityCheck() {
         assertEquals(new PhoneNumberIdentifier("+14255550123"), new PhoneNumberIdentifier("+14255550123"));
         assertNotEquals(new PhoneNumberIdentifier("+14255550123").setRawId("Raw Id"),
             new PhoneNumberIdentifier("+14255550123").setRawId("Another Raw Id"));
@@ -90,7 +187,8 @@ public class CommunicationIdentifierTests {
         assertRawId(new PhoneNumberIdentifier("otherFormat").setRawId("4:207ffef6-9444-41fb-92ab-20eacaae2768"), "4:207ffef6-9444-41fb-92ab-20eacaae2768");
         assertRawId(new PhoneNumberIdentifier("otherFormat").setRawId("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"), "4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768");
         assertRawId(new PhoneNumberIdentifier("otherFormat").setRawId("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"), "4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768");
-        assertRawId(new UnknownIdentifier("28:45ab2481-1c1c-4005-be24-0ffb879b1130"), "28:45ab2481-1c1c-4005-be24-0ffb879b1130");
+
+        assertRawId(new UnknownIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130"), "48:45ab2481-1c1c-4005-be24-0ffb879b1130");
         assertRawId(new UnknownIdentifier("someFutureFormat"), "someFutureFormat");
     }
 
@@ -113,6 +211,14 @@ public class CommunicationIdentifierTests {
         assertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768"));
         assertIdentifier("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768"));
         assertIdentifier("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768", new PhoneNumberIdentifier("+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768"));
+
+        assertIdentifier(CommunicationIdentifier.BOT_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true));
+        assertIdentifier(CommunicationIdentifier.BOT_PUBLIC_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false));
+        assertIdentifier(CommunicationIdentifier.BOT_DOD_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
+        assertIdentifier(CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.DOD));
+        assertIdentifier(CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
+        assertIdentifier(CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
+
         assertIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130", new UnknownIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130"));
 
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
@@ -138,7 +244,12 @@ public class CommunicationIdentifierTests {
         assertRoundTrip("4:207ffef6-9444-41fb-92ab-20eacaae2768");
         assertRoundTrip("4:207ffef6-9444-41fb-92ab-20eacaae2768_207ffef6-9444-41fb-92ab-20eacaae2768");
         assertRoundTrip("4:+112345556789_207ffef6-9444-41fb-92ab-20eacaae2768");
-        assertRoundTrip("28:45ab2481-1c1c-4005-be24-0ffb879b1130");
+        assertRoundTrip(CommunicationIdentifier.BOT_PREFIX + microsoftBotId);
+        assertRoundTrip(CommunicationIdentifier.BOT_PUBLIC_PREFIX + microsoftBotId);
+        assertRoundTrip(CommunicationIdentifier.BOT_DOD_PREFIX + microsoftBotId);
+        assertRoundTrip(CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId);
+        assertRoundTrip(CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId);
+        assertRoundTrip(CommunicationIdentifier.BOT_DOD_GLOBAL_PREFIX + microsoftBotId);
     }
 
     private void assertRawId(CommunicationIdentifier identifier, String expectedRawId)  {

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -219,11 +219,29 @@ public class CommunicationIdentifierTests {
         assertIdentifier(CommunicationIdentifier.BOT_GCCH_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, false).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
         assertIdentifier(CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + microsoftBotId, new MicrosoftBotIdentifier(microsoftBotId, true).setCloudEnvironment(CommunicationCloudEnvironment.GCCH));
 
-        assertIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130", new UnknownIdentifier("48:45ab2481-1c1c-4005-be24-0ffb879b1130"));
-
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> CommunicationIdentifier.fromRawId(null));
         assertEquals("The parameter [rawId] cannot be null to empty.", illegalArgumentException.getMessage());
     }
+
+    @Test
+    public void createIdentifierFromRawId_unknownIdentifierForInvalidMRI() {
+        String [] invalidRawIDs = {
+            "48:45ab2481-1c1c-4005-be24-0ffb879b1130",
+            CommunicationIdentifier.BOT_PREFIX + microsoftBotId + ":newFormat",
+            CommunicationIdentifier.BOT_PUBLIC_PREFIX + microsoftBotId+ ":newFormat:with more segments",
+            CommunicationIdentifier.BOT_GCCH_PREFIX + ":abc-global:" + microsoftBotId,
+            CommunicationIdentifier.BOT_GCCH_GLOBAL_PREFIX + ":abc-global:" + microsoftBotId,
+            CommunicationIdentifier.ACS_GCCH_USER_PREFIX + ":abc:def:1234",
+            CommunicationIdentifier.ACS_USER_PREFIX + ":1:2:3:4:5:6:7:8:9",
+            CommunicationIdentifier.ACS_DOD_USER_PREFIX + ":1:2:3",
+            CommunicationIdentifier.SPOOL_USER_PREFIX + ": other format: :123: 90",
+            CommunicationIdentifier.TEAMS_PUBLIC_USER_PREFIX + ":abc:def:1234"
+        };
+        for (String invalidRawID: invalidRawIDs) {
+            assertIdentifier(invalidRawID, new UnknownIdentifier(invalidRawID));
+        }
+    }
+
 
     @Test
     public void rawIdStaysTheSameAfterConversionToIdentifierAndBack()

--- a/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
+++ b/sdk/communication/azure-communication-common/src/test/java/com/azure/android/communication/common/CommunicationIdentifierTests.java
@@ -23,10 +23,10 @@ public class CommunicationIdentifierTests {
     @Test
     public void microsoftBotIdentifier_throwsMicrosoftBotIdNullOrEmpty() {
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new MicrosoftBotIdentifier(null));
-        assertEquals("The initialization parameter [microsoftBotId] cannot be null or empty.", illegalArgumentException.getMessage());
+        assertEquals("The initialization parameter [botId] cannot be null or empty.", illegalArgumentException.getMessage());
 
         illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> new MicrosoftBotIdentifier(""));
-        assertEquals("The initialization parameter [microsoftBotId] cannot be null or empty.", illegalArgumentException.getMessage());
+        assertEquals("The initialization parameter [botId] cannot be null or empty.", illegalArgumentException.getMessage());
     }
 
     @Test


### PR DESCRIPTION
# Description

Introducing a new type of CommunicationIdentifier - MicrosoftBotIdentifier and the logic is covered with tests.
Implementation of the [User Story 3133111](https://skype.visualstudio.com/SPOOL/_workitems/edit/3133111): [SDK][Common][Mobile] As a developer I can identify if a user is a Teams User or Bot)

API view - [azure-communication-common](https://apiview.dev/Assemblies/Review/c8145aaf77504830b9faf0809da1018f)