### PR TITLE
[android] azure-communication-common release

### DIFF
--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,16 +1,12 @@
 # Release History
 
-## 2.0.0-beta.1 (Unreleased)
+## 2.0.0-beta.1 (2023-04-04)
 
 ### Features Added
 - Added support for a new communication identifier `MicrosoftBotIdentifier`.
 
 ### Breaking Changes
 - Introduction of `MicrosoftBotIdentifier` is a breaking change. It will affect code that relied on using `UnknownIdentifier` with a rawID starting with `28:`
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 1.1.0 (2022-11-11)
 

--- a/sdk/communication/azure-communication-common/README.md
+++ b/sdk/communication/azure-communication-common/README.md
@@ -20,7 +20,7 @@ This package contains common code for Azure Communication Service libraries.
   APIs that would require the Java 8+ API desugaring provided by Android Gradle plugin 4.0.0.
 
 ### Versions available
-The current version of this library is **1.1.0**.
+The current version of this library is **2.0.0-beta.1**.
 
 ### Install the library
 To install the Azure client libraries for Android, add them as dependencies within your
@@ -36,13 +36,13 @@ Add an `implementation` configuration to the `dependencies` block of your app's 
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-common:1.1.0"
+    implementation "com.azure.android:azure-communication-common:2.0.0-beta.1"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-common:1.1.0")
+    implementation("com.azure.android:azure-communication-common:2.0.0-beta.1")
 }
 ```
 
@@ -53,7 +53,7 @@ To import the library into your project using the [Maven](https://maven.apache.o
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-common</artifactId>
-  <version>1.1.0</version>
+  <version>2.0.0-beta.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
azure-communication-common a beta release - 2.0.0-beta.1

- added a new identifier `MicrosoftBotIdentifier
- Introduction of `MicrosoftBotIdentifier` is a breaking change