### PR TITLE
Prepare ACS Common for a beta release - 2.0.0-beta.2

### DIFF
--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-beta.2 (Unreleased)
+## 2.0.0-beta.2 (2023-05-16)
 
 ### Features Added
 - Added new constructor with required param `tokenRefresher` for `CommunicationTokenRefreshOptions`
@@ -14,10 +14,6 @@
 
 ### Breaking Changes
 - Introduced non-nullability check for the argument of `CommunicationCloudEnvironment.fromString(String name)`. It will throw `NullPointerException` if the passed argument is null.
-
-### Bugs Fixed
-
-### Other Changes
 
 ## 2.0.0-beta.1 (2023-04-04)
 

--- a/sdk/communication/azure-communication-common/README.md
+++ b/sdk/communication/azure-communication-common/README.md
@@ -20,7 +20,7 @@ This package contains common code for Azure Communication Service libraries.
   APIs that would require the Java 8+ API desugaring provided by Android Gradle plugin 4.0.0.
 
 ### Versions available
-The current version of this library is **2.0.0-beta.1**.
+The current version of this library is **2.0.0-beta.2**.
 
 ### Install the library
 To install the Azure client libraries for Android, add them as dependencies within your
@@ -36,13 +36,13 @@ Add an `implementation` configuration to the `dependencies` block of your app's 
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-common:2.0.0-beta.1"
+    implementation "com.azure.android:azure-communication-common:2.0.0-beta.2"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-common:2.0.0-beta.1")
+    implementation("com.azure.android:azure-communication-common:2.0.0-beta.2")
 }
 ```
 
@@ -53,7 +53,7 @@ To import the library into your project using the [Maven](https://maven.apache.o
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-common</artifactId>
-  <version>2.0.0-beta.1</version>
+  <version>2.0.0-beta.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
azure-communication-common a beta release(2.0.0-beta.2) which will include following changes:

- Making logic and API consistent with Java API
- Introduced a "fractional" backoff mechanism for the CommunicationTokenCredential

for more info pls  refer to CHANGELOG.md