### PR TITLE
Add CODEOWNERS baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,9 +37,6 @@
 # PRLabel: %Azure.Core
 /sdk/core/                                          @vcolin7 @anuchandy
 
-# PRLabel: %Storage
-/sdk/storage/                                       @vcolin7 @anuchandy
-
 # PRLabel: %EngSys
 /sdk/template/                                      @benbp @weshaggard
 

--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,0 +1,1 @@
+Azure/acs-identity-sdk is an invalid team. Ensure the team exists and has write permissions.


### PR DESCRIPTION
Added the baseline for the CODEOWNERS linter pipeline that's about to be enabled for this repository. Also removed a source path/owner line from CODEOWNERS that doesn't exist (it might have but is no longer in the repository).