### PR TITLE
Fix duplicate real time notifications

### DIFF
--- a/samples/sample-chat-app/build.gradle
+++ b/samples/sample-chat-app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 
 
-    implementation platform('com.google.firebase:firebase-bom:32.2.0')
+    implementation platform('com.google.firebase:firebase-bom:30.1.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
     def work_version = "2.7.1"

--- a/samples/sample-chat-app/build.gradle
+++ b/samples/sample-chat-app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.0.4"
 
 
-    implementation platform('com.google.firebase:firebase-bom:30.1.0')
+    implementation platform('com.google.firebase:firebase-bom:32.2.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-messaging'
     def work_version = "2.7.1"

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## 2.1.0 (2024-01-18)
 
 #### Bugs Fixed
-Address the issue described in https://github.com/Azure/azure-sdk-for-android/issues/1483. The SDK now incorporates more recent Trouter template to prevent Android devices from receiving repeated real-time notifications.
+- Address the issue described in https://github.com/Azure/azure-sdk-for-android/issues/1483. The SDK now incorporates a more recent Trouter template to prevent Android devices from receiving duplicate real-time notifications.
 
 ## 2.0.1 (2023-10-25)
 

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
-## 2.1.0 (2024-01-18)
+## 2.0.2 (2024-01-18)
 
 #### Bugs Fixed
 - Address the issue described in https://github.com/Azure/azure-sdk-for-android/issues/1483. The SDK now incorporates a more recent Trouter template to prevent Android devices from receiving duplicate real-time notifications.

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,13 +1,8 @@
 # Release History
-## 2.1.0-beta.1 (Unreleased)
+## 2.1.0 (2024-01-16)
 
-### Features Added
-
-### Breaking Changes
-
-### Bugs Fixed
-
-### Other Changes
+#### Bugs Fixed
+Fix bug: https://github.com/Azure/azure-sdk-for-android/issues/1483. Latest Trouter template is being used in SDK, to avoid Android device receiving duplicate real time notifications.
 
 ## 2.0.1 (2023-10-25)
 

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History
-## 2.1.0 (2024-01-16)
+## 2.1.0 (2024-01-17)
 
 #### Bugs Fixed
 Fix bug: https://github.com/Azure/azure-sdk-for-android/issues/1483. Latest Trouter template is being used in SDK, to avoid Android device receiving duplicate real time notifications.

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
-## 2.1.0 (2024-01-17)
+## 2.1.0 (2024-01-18)
 
 #### Bugs Fixed
-Fix bug: https://github.com/Azure/azure-sdk-for-android/issues/1483. Latest Trouter template is being used in SDK, to avoid Android device receiving duplicate real time notifications.
+Address the issue described in https://github.com/Azure/azure-sdk-for-android/issues/1483. The SDK now incorporates more recent Trouter template to prevent Android devices from receiving repeated real-time notifications.
 
 ## 2.0.1 (2023-10-25)
 

--- a/sdk/communication/azure-communication-chat/README.md
+++ b/sdk/communication/azure-communication-chat/README.md
@@ -15,7 +15,7 @@ Azure Communication Chat contains the APIs used in chat applications for Azure C
 - A deployed Communication Services resource. You can use the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp) or the [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.communication/new-azcommunicationservice) to set it up.
 
 ### Versions available
-The current version of this library is **2.1.0**.
+The current version of this library is **2.0.2**.
 
 ### Include the package
 To install the Azure Communication Chat libraries for Android, add them as dependencies within your
@@ -31,13 +31,13 @@ Add an `implementation` configuration to the `dependencies` block of your app's 
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-chat:2.1.0"
+    implementation "com.azure.android:azure-communication-chat:2.0.2"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-chat:2.1.0")
+    implementation("com.azure.android:azure-communication-chat:2.0.2")
 }
 ```
 
@@ -48,7 +48,7 @@ To import the library into your project using the [Maven](https://maven.apache.o
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-chat</artifactId>
-  <version>2.1.0</version>
+  <version>2.0.2</version>
 </dependency>
 ```
 

--- a/sdk/communication/azure-communication-chat/README.md
+++ b/sdk/communication/azure-communication-chat/README.md
@@ -15,7 +15,7 @@ Azure Communication Chat contains the APIs used in chat applications for Azure C
 - A deployed Communication Services resource. You can use the [Azure Portal](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource?tabs=windows&pivots=platform-azp) or the [Azure PowerShell](https://docs.microsoft.com/powershell/module/az.communication/new-azcommunicationservice) to set it up.
 
 ### Versions available
-The current version of this library is **2.0.1**.
+The current version of this library is **2.1.0**.
 
 ### Include the package
 To install the Azure Communication Chat libraries for Android, add them as dependencies within your
@@ -31,13 +31,13 @@ Add an `implementation` configuration to the `dependencies` block of your app's 
 // build.gradle
 dependencies {
     ...
-    implementation "com.azure.android:azure-communication-chat:2.0.1"
+    implementation "com.azure.android:azure-communication-chat:2.1.0"
 }
 
 // build.gradle.kts
 dependencies {
     ...
-    implementation("com.azure.android:azure-communication-chat:2.0.1")
+    implementation("com.azure.android:azure-communication-chat:2.1.0")
 }
 ```
 
@@ -48,7 +48,7 @@ To import the library into your project using the [Maven](https://maven.apache.o
 <dependency>
   <groupId>com.azure.android</groupId>
   <artifactId>azure-communication-chat</artifactId>
-  <version>2.0.1</version>
+  <version>2.1.0</version>
 </dependency>
 ```
 

--- a/sdk/communication/azure-communication-chat/env-prod.properties
+++ b/sdk/communication/azure-communication-chat/env-prod.properties
@@ -11,7 +11,7 @@ trouter.registration.hostname="teams.microsoft.com/registrar/prod"
 trouter.registration.hostname.dod="registrar.dod.teams.microsoft.us"
 trouter.registration.hostname.gcch="registrar.gov.teams.microsoft.us"
 trouter.application.id="AcsAndroid"
-trouter.template.key="AcsAndroid_Chat_1.3"
+trouter.template.key="AcsAndroid_Chat_1.7"
 
 pushnotification.registrar.service.url="https://edge.skype.com/registrar/prod/v2/registrations"
 pushnotification.registrar.service.url.dod="https://dod.teams.microsoft.us/v2/registrations"

--- a/sdk/communication/azure-communication-chat/env-prod.properties
+++ b/sdk/communication/azure-communication-chat/env-prod.properties
@@ -11,7 +11,7 @@ trouter.registration.hostname="teams.microsoft.com/registrar/prod"
 trouter.registration.hostname.dod="registrar.dod.teams.microsoft.us"
 trouter.registration.hostname.gcch="registrar.gov.teams.microsoft.us"
 trouter.application.id="AcsAndroid"
-trouter.template.key="AcsAndroid_Chat_1.7"
+trouter.template.key="AcsAndroid_Chat_1.5"
 
 pushnotification.registrar.service.url="https://edge.skype.com/registrar/prod/v2/registrations"
 pushnotification.registrar.service.url.dod="https://dod.teams.microsoft.us/v2/registrations"

--- a/sdk/communication/azure-communication-chat/env-test.properties
+++ b/sdk/communication/azure-communication-chat/env-test.properties
@@ -10,7 +10,7 @@ trouter.registration.hostname="edge.skype.net/registrar/testenv"
 trouter.registration.hostname.dod="dod_not_supported_in_test_env"
 trouter.registration.hostname.gcch="gcch_not_supported_in_test_env"
 trouter.application.id="AcsAndroid_test"
-trouter.template.key="AcsAndroid_Chat_test_1.3"
+trouter.template.key="AcsAndroid_Chat_test_1.7"
 
 pushnotification.registrar.service.url="https://edge.skype.net/registrar/testenv/v2/registrations"
 pushnotification.registrar.service.url.dod="dod_not_supported_in_test_env"

--- a/sdk/communication/azure-communication-chat/env-test.properties
+++ b/sdk/communication/azure-communication-chat/env-test.properties
@@ -10,7 +10,7 @@ trouter.registration.hostname="edge.skype.net/registrar/testenv"
 trouter.registration.hostname.dod="dod_not_supported_in_test_env"
 trouter.registration.hostname.gcch="gcch_not_supported_in_test_env"
 trouter.application.id="AcsAndroid_test"
-trouter.template.key="AcsAndroid_Chat_test_1.7"
+trouter.template.key="AcsAndroid_Chat_test_1.5"
 
 pushnotification.registrar.service.url="https://edge.skype.net/registrar/testenv/v2/registrations"
 pushnotification.registrar.service.url.dod="dod_not_supported_in_test_env"

--- a/sdk/communication/azure-communication-chat/gradle.properties
+++ b/sdk/communication/azure-communication-chat/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.0
+version=2.0.2

--- a/sdk/communication/azure-communication-chat/gradle.properties
+++ b/sdk/communication/azure-communication-chat/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.0-beta.1
+version=2.1.0


### PR DESCRIPTION
Fixes: #1483.

https://portal.microsofticm.com/imp/v3/incidents/details/457409680/home.

Customers report getting two real time notifications for single request using Android SDK. We are able to reproduce the issue locally. The root cause is the outdated Trouter template which misses the Trouter-control header. Directly modifying the template is risky because most users use this outdated template. 

Making this change to use latest version of template "AcsAndroid_Chat_test_1.7". Tested this change locally