### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,13 +12,6 @@
 # /config/
 # /doc/
 
-################
-# Automation
-################
-
-# Git Hub integration and bot rules
-/.github/                                           @jsquire @ronniegeraghty
-
 ###########
 # SDK
 ###########


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.