### PR TITLE
Updated `targetSdkVersion` and `compileSdkVersion`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,12 +51,12 @@ configure(subprojects.findAll { it.path.startsWith(':sdk:') && it.path.count(':'
     group = "com.azure.android"
 
     android {
-        compileSdkVersion 30
+        compileSdkVersion 34
         buildToolsVersion ("$gradleAndroidBuildToolsPluginVersion")
 
         defaultConfig {
             minSdkVersion 15
-            targetSdkVersion 30
+            targetSdkVersion 34
             testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -100,10 +100,15 @@ configure(subprojects.findAll { it.path.startsWith(':sdk:') && it.path.count(':'
         }
 
         testOptions {
-            unitTests {
-                includeAndroidResources = true
-                returnDefaultValues = true
+            unitTests.all {
+                jacoco {
+                    includeNoLocationClasses = true
+                    excludes = ['jdk.internal.*']
+                }
             }
+
+            unitTests.includeAndroidResources = true
+            unitTests.returnDefaultValues = true
         }
     }
 
@@ -113,17 +118,13 @@ configure(subprojects.findAll { it.path.startsWith(':sdk:') && it.path.count(':'
 
     task jacocoTestReport(type: JacocoReport) {
         group = "Reporting"
-        description = "Generate Jacoco coverage reports"
+        description = "Generate Jacoco reports"
+
         reports {
             xml.enabled = true
             html.enabled = false
             csv.enabled = false
         }
-    }
-
-    tasks.withType(Test) {
-        junitJacoco.includeNoLocationClasses = true
-        junitJacoco.excludes = ['jdk.internal.*']
     }
 
     // Add dependency to the module containing azure custom checkstyle.

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -2,6 +2,6 @@ variables:
     Pool: azsdk-pool-mms-ubuntu-2004-general
     OSVmImage: MMSUbuntu20.04
     DocWardenVersion: '0.4.2'
-    JavaBuildVersion: '1.8'
-    JavaTestVersion: '1.8'
+    JavaBuildVersion: '1.11'
+    JavaTestVersion: '1.11'
     Package.EnableSBOMSigning: true

--- a/samples/sample-chat-app/build.gradle
+++ b/samples/sample-chat-app/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "com.azure.android.communication.chat.sampleapp"
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 34
     }
 
     buildTypes {

--- a/samples/sample-chat-app/src/main/AndroidManifest.xml
+++ b/samples/sample-chat-app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
       android:supportsRtl="true"
       android:name=".MyAppConfiguration"
       >
-    <activity android:name="com.azure.android.communication.chat.sampleapp.MainActivity">
+    <activity android:name="com.azure.android.communication.chat.sampleapp.MainActivity"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 

--- a/sdk/communication/azure-communication-chat/CHANGELOG.md
+++ b/sdk/communication/azure-communication-chat/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugs Fixed
 
 ### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
 
 ## 2.0.2 (2024-01-18)
 

--- a/sdk/communication/azure-communication-common/CHANGELOG.md
+++ b/sdk/communication/azure-communication-common/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Other Changes
 - Introduction of `MicrosoftTeamsAppIdentifier` is a breaking change. It will impact any code that previously depended on the use of UnknownIdentifier with rawIDs starting with `28:orgid:`, `28:dod:`, or `28:gcch:`.
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
 
 ### Bugs Fixed
 

--- a/sdk/core/azure-core-credential/CHANGELOG.md
+++ b/sdk/core/azure-core-credential/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core-logging` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core-credential/README.md
+++ b/sdk/core/azure-core-credential/README.md
@@ -17,7 +17,7 @@ Azure Core Credentials provides shared primitives, abstractions, and helpers aut
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-credential</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-credential/gradle.properties
+++ b/sdk/core/azure-core-credential/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-http-httpurlconnection/CHANGELOG.md
+++ b/sdk/core/azure-core-http-httpurlconnection/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-http` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 #### Dependency updates

--- a/sdk/core/azure-core-http-httpurlconnection/README.md
+++ b/sdk/core/azure-core-http-httpurlconnection/README.md
@@ -17,7 +17,7 @@ Azure Core HttpUrlConnection HTTP client is a plugin for the `azure-core` HTTP c
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-http-httpurlconnection</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-http-httpurlconnection/gradle.properties
+++ b/sdk/core/azure-core-http-httpurlconnection/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-http-okhttp/CHANGELOG.md
+++ b/sdk/core/azure-core-http-okhttp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-logging` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core-http-okhttp/README.md
+++ b/sdk/core/azure-core-http-okhttp/README.md
@@ -17,7 +17,7 @@ Azure Core OkHttp HTTP client is a plugin for the `azure-core` HTTP client API.
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-http-okhttp</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-http-okhttp/gradle.properties
+++ b/sdk/core/azure-core-http-okhttp/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-http/CHANGELOG.md
+++ b/sdk/core/azure-core-http/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-credential` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-logging` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core-http/README.md
+++ b/sdk/core/azure-core-http/README.md
@@ -17,7 +17,7 @@ Azure Core HTTP provides shared primitives, abstractions, and helpers for concre
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-http</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-http/gradle.properties
+++ b/sdk/core/azure-core-http/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-jackson/CHANGELOG.md
+++ b/sdk/core/azure-core-jackson/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core-jackson/README.md
+++ b/sdk/core/azure-core-jackson/README.md
@@ -17,7 +17,7 @@ Azure Core library for serialization and deserialization using Jackson.
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-jackson</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-jackson/gradle.properties
+++ b/sdk/core/azure-core-jackson/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-logging/CHANGELOG.md
+++ b/sdk/core/azure-core-logging/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ## 1.0.0-beta.12 (2022-11-08)

--- a/sdk/core/azure-core-logging/README.md
+++ b/sdk/core/azure-core-logging/README.md
@@ -17,7 +17,7 @@ Azure Core logging provides shared primitives, abstractions, and helpers for log
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-logging</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-logging/gradle.properties
+++ b/sdk/core/azure-core-logging/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-rest/CHANGELOG.md
+++ b/sdk/core/azure-core-rest/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-http` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-jackson` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-logging` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core-rest/README.md
+++ b/sdk/core/azure-core-rest/README.md
@@ -17,7 +17,7 @@ Azure Core REST provides client abstraction to make HTTP REST Calls.
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-rest</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-rest/gradle.properties
+++ b/sdk/core/azure-core-rest/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core-test/CHANGELOG.md
+++ b/sdk/core/azure-core-test/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-jackson` dependency version to `1.0.0-beta.14`.
+- Updated `azure-core-rest` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core-test/README.md
+++ b/sdk/core/azure-core-test/README.md
@@ -18,7 +18,7 @@ To use this package, add the following to your _pom.xml_.
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core-test</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core-test/gradle.properties
+++ b/sdk/core/azure-core-test/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/core/azure-core/CHANGELOG.md
+++ b/sdk/core/azure-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.0.0-beta.14 (2024-02-14)
+
+### Other Changes
+- Updated `targetSdkVersion` and `compileSdkVersion` from `30` to `34`.
+
+#### Dependency updates
+- Updated `azure-core-logging` dependency version to `1.0.0-beta.14`.
+
 ## 1.0.0-beta.13 (2023-10-12)
 
 ### Other Changes

--- a/sdk/core/azure-core/README.md
+++ b/sdk/core/azure-core/README.md
@@ -17,7 +17,7 @@ Azure Core Micro provides shared primitives, abstractions, and helpers for moder
 <dependency>
     <groupId>com.azure</groupId>
     <artifactId>azure-core</artifactId>
-    <version>1.0.0-beta.13</version>
+    <version>1.0.0-beta.14</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})

--- a/sdk/core/azure-core/gradle.properties
+++ b/sdk/core/azure-core/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.13
+version=1.0.0-beta.14


### PR DESCRIPTION
The [Google Play Store's guidelines](https://developer.android.com/google/play/requirements/target-sdk) dictate that, as of August 31st, 2023, new apps should target Android API level 33+, and existing apps should target Android API level 31+. August 31st became the de-facto date where API levels shall be updated for subsequent years as new API levels of Android are released.

I have updated our `targetSdkVersion` and `compileSdkVersion` to use the latest API level instead (34, released in October, 2023), as this will be required by the Google Play Store come next August. It also allows our users to test out the latest Android features in their apps by not locking them to an earlier level like 31 or 33.