### PR TITLE
Changes to publishing scripts/yml to remove Maven publishing

### DIFF
--- a/eng/maven.publish.settings.xml
+++ b/eng/maven.publish.settings.xml
@@ -1,4 +1,4 @@
-<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" 
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                       https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
@@ -21,15 +21,4 @@
   <activeProfiles>
     <activeProfile>signing</activeProfile>
   </activeProfiles>
-
-  <!--
-  NOTE: Maven Central downloads are quite unreliable. This gives us better reliability.
-  -->
-  <mirrors>
-      <mirror>
-          <id>repo-maven-apache-org-mirror</id>
-          <url>https://repo-maven-apache-org.azurefd.net/maven2</url>
-          <mirrorOf>central</mirrorOf>
-      </mirror>
-  </mirrors>
 </settings>

--- a/eng/pipelines/templates/steps/java-publishing.yml
+++ b/eng/pipelines/templates/steps/java-publishing.yml
@@ -89,7 +89,7 @@ steps:
           SignCertName: 'azure-sdk-esrp-release-sign-certificate'
           Intent: 'PackageDistribution'
           ContentType: 'Maven'
-          PackageLocation: $(PackageLocation)
+          FolderLocation: $(PackageLocation)
           Owners: $(Build.RequestedForEmail)
           Approvers: 'wesh@microsoft.com'
           ServiceEndpointUrl: 'https://api.esrp.microsoft.com'

--- a/eng/pipelines/templates/steps/java-publishing.yml
+++ b/eng/pipelines/templates/steps/java-publishing.yml
@@ -19,8 +19,8 @@ steps:
         filePath: ${{ parameters.JavaRepoRoot }}/eng/scripts/Publish-MavenPackages.ps1
         arguments: >
           -ArtifactDirectory ${{ parameters.ArtifactDirectory }}
-          -GroupIDFilter ${{ parameters.GroupID }}
-          -ArtifactIDFilter ${{ parameters.ArtifactID }}
+          -GroupIDFilter "${{ parameters.GroupID }}"
+          -ArtifactIDFilter "${{ parameters.ArtifactID }}"
           -RepositoryUrl https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-$(Build.BuildID)/maven/v1
           -RepositoryUsername nobody
           -RepositoryPassword $(System.AccessToken)
@@ -37,8 +37,8 @@ steps:
         filePath: ${{ parameters.JavaRepoRoot }}/eng/scripts/Publish-MavenPackages.ps1
         arguments: >
           -ArtifactDirectory ${{ parameters.ArtifactDirectory }}
-          -GroupIDFilter ${{ parameters.GroupID }}
-          -ArtifactIDFilter ${{ parameters.ArtifactID }}
+          -GroupIDFilter "${{ parameters.GroupID }}"
+          -ArtifactIDFilter "${{ parameters.ArtifactID }}"
           -RepositoryUrl ${{ parameters.RepositoryUrl }}
           -RepositoryUsername nobody
           -RepositoryPassword $(System.AccessToken)
@@ -55,31 +55,12 @@ steps:
         filePath: ${{ parameters.JavaRepoRoot }}/eng/scripts/Publish-MavenPackages.ps1
         arguments: >
           -ArtifactDirectory ${{ parameters.ArtifactDirectory }}
-          -GroupIDFilter ${{ parameters.GroupID }}
-          -ArtifactIDFilter ${{ parameters.ArtifactID }}
+          -GroupIDFilter "${{ parameters.GroupID }}"
+          -ArtifactIDFilter "${{ parameters.ArtifactID }}"
           -RepositoryUrl https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-android/maven/v1
           -RepositoryUsername nobody
           -RepositoryPassword $(System.AccessToken)
           -GPGExecutablePath ${{ parameters.GPGExecutablePath }}
-          -ShouldPublish:$${{parameters.ShouldPublish}}
-          -InformationAction Continue
-
-  - ${{if eq(parameters.Target, 'MavenCentral')}}:
-    - task: PowerShell@2
-      displayName: 'Publish to Maven Central'
-      inputs:
-        pwsh: true
-        workingDirectory: $(Agent.BuildDirectory)
-        filePath: ${{ parameters.JavaRepoRoot }}/eng/scripts/Publish-MavenPackages.ps1
-        arguments: >
-          -ArtifactDirectory ${{ parameters.ArtifactDirectory }}
-          -GroupIDFilter "${{ parameters.GroupID }}"
-          -ArtifactIDFilter "${{ parameters.ArtifactID }}"
-          -RepositoryUrl https://oss.sonatype.org/service/local/staging/deploy/maven2/
-          -RepositoryUsername azuresdk
-          -RepositoryPassword $(azuresdk-sonatype-password)
-          -GPGExecutablePath ${{ parameters.GPGExecutablePath }}
-          -StageOnly:$${{parameters.StageOnly}}
           -ShouldPublish:$${{parameters.ShouldPublish}}
           -InformationAction Continue
 
@@ -101,7 +82,11 @@ steps:
       - task: EsrpRelease@1
         displayName: 'Publish to ESRP'
         inputs:
-          ConnectedServiceName: 'ESRP Release Service'
+          ConnectedServiceName: 'Azure SDK Engineering System'
+          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+          KeyVaultName: 'AzureSDKEngKeyVault'
+          AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+          SignCertName: 'azure-sdk-esrp-release-sign-certificate'
           Intent: 'PackageDistribution'
           ContentType: 'Maven'
           PackageLocation: $(PackageLocation)

--- a/eng/pipelines/templates/steps/java-publishing.yml
+++ b/eng/pipelines/templates/steps/java-publishing.yml
@@ -79,10 +79,14 @@ steps:
           -GPGExecutablePath ${{ parameters.GPGExecutablePath }}
           -InformationAction Continue
     - ${{if and(eq(parameters.ShouldPublish, 'true'), ne(parameters.StageOnly, 'true'))}}:
-      - task: EsrpRelease@1
+      - task: EsrpRelease@7
         displayName: 'Publish to ESRP'
         inputs:
-          ConnectedServiceName: 'ESRP Release Service'
+          ConnectedServiceName: 'Azure SDK Engineering System'
+          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+          KeyVaultName: 'AzureSDKEngKeyVault'
+          AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+          SignCertName: 'azure-sdk-esrp-release-sign-certificate'
           Intent: 'PackageDistribution'
           ContentType: 'Maven'
           PackageLocation: $(PackageLocation)
@@ -91,20 +95,4 @@ steps:
           ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
           MainPublisher: 'ESRPRELPACMANTEST'
           DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-      # - task: EsrpRelease@7
-      #   displayName: 'Publish to ESRP'
-      #   inputs:
-      #     ConnectedServiceName: 'Azure SDK Engineering System'
-      #     ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-      #     KeyVaultName: 'AzureSDKEngKeyVault'
-      #     AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
-      #     SignCertName: 'azure-sdk-esrp-release-sign-certificate'
-      #     Intent: 'PackageDistribution'
-      #     ContentType: 'Maven'
-      #     PackageLocation: $(PackageLocation)
-      #     Owners: $(Build.RequestedForEmail)
-      #     Approvers: 'wesh@microsoft.com'
-      #     ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-      #     MainPublisher: 'ESRPRELPACMANTEST'
-      #     DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
 

--- a/eng/pipelines/templates/steps/java-publishing.yml
+++ b/eng/pipelines/templates/steps/java-publishing.yml
@@ -79,14 +79,10 @@ steps:
           -GPGExecutablePath ${{ parameters.GPGExecutablePath }}
           -InformationAction Continue
     - ${{if and(eq(parameters.ShouldPublish, 'true'), ne(parameters.StageOnly, 'true'))}}:
-      - task: EsrpRelease@7
+      - task: EsrpRelease@1
         displayName: 'Publish to ESRP'
         inputs:
-          ConnectedServiceName: 'Azure SDK Engineering System'
-          ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-          KeyVaultName: 'AzureSDKEngKeyVault'
-          AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
-          SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+          ConnectedServiceName: 'ESRP Release Service'
           Intent: 'PackageDistribution'
           ContentType: 'Maven'
           PackageLocation: $(PackageLocation)
@@ -95,4 +91,20 @@ steps:
           ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
           MainPublisher: 'ESRPRELPACMANTEST'
           DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+      # - task: EsrpRelease@7
+      #   displayName: 'Publish to ESRP'
+      #   inputs:
+      #     ConnectedServiceName: 'Azure SDK Engineering System'
+      #     ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+      #     KeyVaultName: 'AzureSDKEngKeyVault'
+      #     AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+      #     SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+      #     Intent: 'PackageDistribution'
+      #     ContentType: 'Maven'
+      #     PackageLocation: $(PackageLocation)
+      #     Owners: $(Build.RequestedForEmail)
+      #     Approvers: 'wesh@microsoft.com'
+      #     ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+      #     MainPublisher: 'ESRPRELPACMANTEST'
+      #     DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
 

--- a/eng/pipelines/templates/steps/java-publishing.yml
+++ b/eng/pipelines/templates/steps/java-publishing.yml
@@ -79,7 +79,7 @@ steps:
           -GPGExecutablePath ${{ parameters.GPGExecutablePath }}
           -InformationAction Continue
     - ${{if and(eq(parameters.ShouldPublish, 'true'), ne(parameters.StageOnly, 'true'))}}:
-      - task: EsrpRelease@1
+      - task: EsrpRelease@7
         displayName: 'Publish to ESRP'
         inputs:
           ConnectedServiceName: 'Azure SDK Engineering System'

--- a/eng/scripts/MavenPackaging.ps1
+++ b/eng/scripts/MavenPackaging.ps1
@@ -10,7 +10,6 @@ class MavenPackageDetail {
   [string]$ArtifactID
   [string]$Version
   [bool]$IsSnapshot
-  [string]$SonaTypeProfileID
   [AssociatedArtifact[]]$AssociatedArtifacts
 }
 
@@ -63,35 +62,6 @@ function Get-AssociatedArtifacts([MavenPackageDetail]$PackageDetail) {
   return $associatedArtifacts
 }
 
-# This function maps the group ID that is detected in the POM file against a
-# know set of mappings to SonaType Nexus profile IDs. A profile ID is needed
-# to stage a Maven package in https://oss.sonatype.org prior to being "released"
-# into the public Maven Central repository (and mirrors).
-#
-# NOTE that the current azuresdk SonaType user identity has access to all of
-# the profile Ids below for publishing. If a new profile is introduced then
-# the azuresdk identity will need to be granted access to it so that it can
-# publish to it.
-function Get-SonaTypeProfileID([string]$GroupID) {
-  $sonaTypeProfileID = switch -wildcard ($GroupID)
-  {
-    "com.azure*"                     { "88192f04117501" }
-    "com.microsoft"                  { "108eda13eb3910" }
-    "com.microsoft.azure*"           { "534d15ee3800f4" }
-    "com.microsoft.commondatamodel*" { "36ba35bb1eff8"  }
-    "com.microsoft.rest*"            { "66eef5eb9b85bd" }
-    "com.microsoft.servicefabric*"   { "8acff2e04dc15e" }
-    "com.microsoft.spring*"          { "615994e851c580" }
-    "com.microsoft.sqlserver*"       { "2bafd8aecdb240" }
-    "com.windowsazure*"              { "222b383b84716"  }
-    default {
-      throw "Profile ID for group ID $GroupID was not found."
-    }
-  }
-
-  return $sonaTypeProfileID
-}
-
 # This function returns an array of object where each object represents a logical Maven package
 # including all of its associated artifacts. It takes care of extracting out group ID, artifact ID,
 # and version information, as well as providing metadata for each of the associated files including
@@ -126,9 +96,6 @@ function Get-MavenPackageDetails([string]$ArtifactDirectory) {
 
     $packageDetail.IsSnapshot = $packageDetail.Version.EndsWith("-SNAPSHOT")
     Write-Information "IsSnapshot is: $($packageDetail.IsSnapshot)"
-
-    $packageDetail.SonaTypeProfileID = Get-SonaTypeProfileID($packageDetail.GroupID)
-    Write-Information "SonaType Profile ID is: $($packageDetail.SonaTypeProfileID)"
 
     $packageDetail.FullyQualifiedName = "$($packageDetail.GroupID):$($packageDetail.ArtifactID):$($packageDetail.Version)"
     Write-Information "Fully-qualified name is: $($packageDetail.FullyQualifiedName)"

--- a/eng/scripts/Publish-MavenPackages.ps1
+++ b/eng/scripts/Publish-MavenPackages.ps1
@@ -128,23 +128,9 @@ foreach ($packageDetail in $packageDetails) {
   if ($packageReposityUrl -match "https://pkgs.dev.azure.com/azure-sdk/\b(internal|public)\b/*") {
     # Azure DevOps feeds don't support staging
     $shouldPublishPackage = $ShouldPublish -and !$StageOnly
-    $releaseType = 'AzureDevOps'
-  }
-  elseif ($packageReposityUrl -like "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-    if ($packageDetail.IsSnapshot) {
-      # Snapshots don't go to the standard maven central url
-      $packageReposityUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-      $releaseType = 'MavenCentralSnapshot'
-    }
-    elseif ($StageOnly) {
-      $releaseType = 'MavenCentralStaging'
-    }
-    else {
-      $releaseType = 'MavenCentral'
-    }
   }
   else {
-    throw "Repository URL must be either an Azure Artifacts feed, or a SonaType Nexus feed."
+    throw "Repository URL must be an Azure Artifacts feed, anything else must be published through ESRP."
   }
 
   #Local GPG deployment is required when we're not going to publish a package, or when we're publishing to maven central
@@ -161,6 +147,15 @@ foreach ($packageDetail in $packageDetails) {
   $gpgexeOption = "-Dgpgexe=$GPGExecutablePath"
   Write-Information "GPG Executable Option is: $gpgexeOption"
 
+  $gpgPluginVersion = . $PSScriptRoot\Get-ExternalDependencyVersion.ps1 -GroupId 'org.apache.maven.plugins' -ArtifactId 'maven-gpg-plugin'
+  if ($LASTEXITCODE) {
+    Write-Information "##vso[task.logissue type=error]Unable to resolve version of external dependency 'org.apache.maven.plugins:maven-gpg-plugin'"
+    exit $LASTEXITCODE
+  }
+
+  $gpgSignAndDeployWithVer = "org.apache.maven.plugins:maven-gpg-plugin:$gpgPluginVersion`:sign-and-deploy-file"
+
+
   if ($requiresLocalGpg) {
     $localRepositoryDirectory = Get-RandomRepositoryDirectory
     $localRepositoryDirectoryUri = $([Uri]$localRepositoryDirectory.FullName).AbsoluteUri
@@ -170,8 +165,8 @@ foreach ($packageDetail in $packageDetails) {
     Write-Information "URL Option is: $urlOption"
 
     Write-Information "Signing and deploying package to $localRepositoryDirectoryUri"
-    Write-Information "mvn gpg:sign-and-deploy-file `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"$urlOption`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-    mvn gpg:sign-and-deploy-file "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
+    Write-Information "mvn $gpgSignAndDeployWithVer `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"$urlOption`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
+    mvn $gpgSignAndDeployWithVer "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "$urlOption" "$gpgexeOption" "-DrepositoryId=target-repo" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
   }
 
@@ -181,121 +176,23 @@ foreach ($packageDetail in $packageDetails) {
     continue
   }
 
-  if ($releaseType -eq 'AzureDevOps') {
-    Write-Information "GPG Signing and deploying package in one step to devops feed: $packageReposityUrl"
-    Write-Information "mvn gpg:sign-and-deploy-file `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"-Durl=$packageReposityUrl`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"-Drepo.password=[redacted]`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-    mvn gpg:sign-and-deploy-file "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "-Durl=$packageReposityUrl" "$gpgexeOption" "-DrepositoryId=target-repo" "-Drepo.password=$RepositoryPassword" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
+  Write-Information "GPG Signing and deploying package in one step to devops feed: $packageReposityUrl"
+  Write-Information "mvn $gpgSignAndDeployWithVer `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"-Durl=$packageReposityUrl`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"-Drepo.password=[redacted]`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
+  mvn $gpgSignAndDeployWithVer "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "-Durl=$packageReposityUrl" "$gpgexeOption" "-DrepositoryId=target-repo" "-Drepo.password=$RepositoryPassword" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
 
-    if ($LASTEXITCODE -eq 0) {
-      Write-Information "Package $($packageDetail.FullyQualifiedName) deployed"
-      continue
-    }
-
-    Write-Information "Release attempt $attemt exited with code $LASTEXITCODE"
-    Write-Information "Checking Azure DevOps to see if release was successful"
-    if (Test-ReleasedPackage -RepositoryUrl $packageReposityUrl -PackageDetail $packageDetail -BearerToken $RepositoryPassword) {
-      Write-Information "Package $($packageDetail.FullyQualifiedName) deployed despite non-zero exit code."
-      continue
-    }
-
-    exit $LASTEXITCODE
+  if ($LASTEXITCODE -eq 0) {
+    Write-Information "Package $($packageDetail.FullyQualifiedName) deployed"
+    continue
   }
-  elseif ($releaseType -eq 'MavenCentralSnapshot') {
-    Write-Information "GPG Signing and deploying package in one step to Sonatype snapshots: $packageReposityUrl"
-    Write-Information "mvn gpg:sign-and-deploy-file `"--batch-mode`" `"$pomOption`" `"$fileOption`" `"$javadocOption`" `"$sourcesOption`" `"$filesOption`" $classifiersOption `"$typesOption`" `"-Durl=$packageReposityUrl`" `"$gpgexeOption`" `"-DrepositoryId=target-repo`" `"-Drepo.username=`"`"$RepositoryUsername`"`"`" `"-Drepo.password=[redacted]`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-    mvn gpg:sign-and-deploy-file "--batch-mode" "$pomOption" "$fileOption" "$javadocOption" "$sourcesOption" "$filesOption" $classifiersOption "$typesOption" "-Durl=$packageReposityUrl" "$gpgexeOption" "-DrepositoryId=target-repo" "-Drepo.username=""$RepositoryUsername""" "-Drepo.password=""$RepositoryPassword""" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
-    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
+  Write-Information "Release attempt $attemt exited with code $LASTEXITCODE"
+  Write-Information "Checking Azure DevOps to see if release was successful"
+  if (Test-ReleasedPackage -RepositoryUrl $packageReposityUrl -PackageDetail $packageDetail -BearerToken $RepositoryPassword) {
+    Write-Information "Package $($packageDetail.FullyQualifiedName) deployed despite non-zero exit code."
+    continue
   }
-  else {
 
-    $resultsTime = [diagnostics.stopwatch]::StartNew()
-    # IsMavenPackageVersionPublished is a very quick check to see if the pom is on maven which takes about 1-2 seconds
-    # to complete. If the POM if there, Test-ReleasedPackage will look at all of the package artifacts (pom, jars, .md)
-    # and compare their hashes. The reason we need the quick check first, is that Test-ReleasedPackage, when called
-    # on something that hasn't been released, takes 90 seconds if none of the artifacts have been released and about
-    # 25 seconds, if they have. The first time an artifact is being released we use IsMavenPackageVersionPublished so
-    # we don't add 90 seconds on to every Maven release.
-    if (IsMavenPackageVersionPublished -pkgId $packageDetail.ArtifactID -pkgVersion $packageDetail.Version -groupId $packageDetail.GroupId) {
-      if (Test-ReleasedPackage -RepositoryUrl $packageReposityUrl -PackageDetail $packageDetail) {
-        Write-Information "Package $($packageDetail.FullyQualifiedName) has already been deployed."
-        continue
-      }
-    } else {
-      Write-Information "$($packageDetail.FullyQualifiedName) has not yet deployed."
-    }
-    Write-Information "Time to test released package=$($resultstime.Elapsed.ToString('dd\.hh\:mm\:ss'))"
-
-    # Maven Central Staging + optional Release
-    $repositoryDirectoryOption = "-DrepositoryDirectory=$localRepositoryDirectory"
-    Write-Information "Repository Directory Option is: $repositoryDirectoryOption"
-
-    $stagingProfileIdOption = "-DstagingProfileId=$($packageDetail.SonaTypeProfileID)"
-    Write-Information "Staging Profile ID Option is: $stagingProfileIdOption"
-
-    $stagingDescriptionOption = "-DstagingDescription=$($packageDetail.FullyQualifiedName)"
-    Write-Information "Staging Description Option is: $stagingDescriptionOption"
-
-    $nexusPluginVersion = . $PSScriptRoot\Get-ExternalDependencyVersion.ps1 -GroupId 'org.sonatype.plugins' -ArtifactId 'nexus-staging-maven-plugin'
-    if ($LASTEXITCODE) {
-      Write-Information "##vso[task.logissue type=error]Unable to resolve version of external dependency 'org.sonatype.plugins:nexus-staging-maven-plugin'"
-      exit $LASTEXITCODE
-    }
-
-    $stagingGoal = "org.sonatype.plugins:nexus-staging-maven-plugin:$nexusPluginVersion`:deploy-staged-repository"
-    $releaseGoal = "org.sonatype.plugins:nexus-staging-maven-plugin:$nexusPluginVersion`:rc-release"
-
-    Write-Information "Staging package to Maven Central"
-    Write-Information "mvn $stagingGoal `"--batch-mode`" `"-DnexusUrl=https://oss.sonatype.org`" `"$repositoryDirectoryOption`" `"$stagingProfileIdOption`" `"$stagingDescriptionOption`" `"-DrepositoryId=target-repo`" `"-DserverId=target-repo`" `"-Drepo.username=$RepositoryUsername`" `"-Drepo.password=`"[redacted]`"`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-    mvn $stagingGoal "--batch-mode" "-DnexusUrl=https://oss.sonatype.org" "$repositoryDirectoryOption" "$stagingProfileIdOption" "$stagingDescriptionOption" "-DrepositoryId=target-repo" "-DserverId=target-repo" "-Drepo.username=$RepositoryUsername" "-Drepo.password=""$RepositoryPassword""" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
-
-    if ($LASTEXITCODE) {
-      Write-Information '##vso[task.logissue type=error]Staging to Maven Central failed. For troubleshooting, see https://aka.ms/azsdk/maven-central-tsg'
-      exit $LASTEXITCODE
-    }
-
-    Write-Information "Reading staging properties."
-    $stagedRepositoryProperties = ConvertFrom-StringData (Get-Content "$localRepositoryDirectory\$($packageDetail.SonaTypeProfileID).properties" -Raw)
-
-    $stagedRepositoryId = $stagedRepositoryProperties["stagingRepository.id"]
-    Write-Information "Staging Repository ID is: $stagedRepositoryId"
-
-    $stagedRepositoryUrl = $stagedRepositoryProperties["stagingRepository.url"]
-    Write-Information "Staging Repository URL is: $stagedRepositoryUrl"
-
-    if ($releaseType -eq 'MavenCentralStaging') {
-      Write-Information "Skipping release of staging repository because Stage Only == true."
-      continue
-    }
-
-    $attempt = 0
-    $success = $false;
-
-    while ($attempt++ -lt 3) {
-      Write-Information "Releasing staging repostiory $stagedRepositoryId, attempt $attempt"
-      Write-Information "mvn $releaseGoal `"-DstagingRepositoryId=$stagedRepositoryId`" `"-DnexusUrl=https://oss.sonatype.org`" `"-DrepositoryId=target-repo`" `"-DserverId=target-repo`" `"-Drepo.username=$RepositoryUsername`" `"-Drepo.password=`"`"[redacted]`"`"`" `"--settings=$PSScriptRoot\..\maven.publish.settings.xml`""
-      mvn $releaseGoal "-DstagingRepositoryId=$stagedRepositoryId" "-DnexusUrl=https://oss.sonatype.org" "-DrepositoryId=target-repo" "-DserverId=target-repo" "-Drepo.username=$RepositoryUsername" "-Drepo.password=""$RepositoryPassword""" "--settings=$PSScriptRoot\..\maven.publish.settings.xml"
-
-      if ($LASTEXITCODE -eq 0) {
-        Write-Information "Package $($packageDetail.FullyQualifiedName) deployed"
-        $success = $true
-        break
-      }
-
-      Write-Information "Release attempt $attempt exited with code $LASTEXITCODE"
-      Write-Information "Checking Maven Central to see if release was successful"
-
-      if (Test-ReleasedPackage -RepositoryUrl $packageReposityUrl -PackageDetail $packageDetail) {
-        Write-Information "Package $($packageDetail.FullyQualifiedName) deployed despite non-zero exit code."
-        $success = $true
-        break
-      }
-    }
-
-    if (!$success) {
-      Write-Information '##vso[task.logissue type=error]Release to Maven Central failed. For troubleshooting, see https://aka.ms/azsdk/maven-central-tsg'
-      exit 1
-    }
-  }
+  exit $LASTEXITCODE
 }
 
 exit 0

--- a/eng/scripts/SignAndHash-MavenPackages.ps1
+++ b/eng/scripts/SignAndHash-MavenPackages.ps1
@@ -180,6 +180,7 @@ foreach ($packageDetail in $packageDetails) {
     exit 1
   }
 
+  Write-Host "Setting packageLocation to '$signedArtifactPath'"
   Write-Host "##vso[task.setvariable variable=packageLocation]$signedArtifactPath"
   Write-Host ""
 }

--- a/eng/scripts/SignAndHash-MavenPackages.ps1
+++ b/eng/scripts/SignAndHash-MavenPackages.ps1
@@ -181,6 +181,7 @@ foreach ($packageDetail in $packageDetails) {
   }
 
   Write-Host "Setting packageLocation to '$signedArtifactPath'"
+  Get-ChildItem -Path $signedArtifactPath
   Write-Host "##vso[task.setvariable variable=packageLocation]$signedArtifactPath"
   Write-Host ""
 }

--- a/eng/scripts/SignAndHash-MavenPackages.ps1
+++ b/eng/scripts/SignAndHash-MavenPackages.ps1
@@ -180,8 +180,6 @@ foreach ($packageDetail in $packageDetails) {
     exit 1
   }
 
-  Write-Host "Setting packageLocation to '$signedArtifactPath'"
-  Get-ChildItem -Path $signedArtifactPath
   Write-Host "##vso[task.setvariable variable=packageLocation]$signedArtifactPath"
   Write-Host ""
 }

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.16
+version=1.0.0-beta.17

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.18
+version=1.0.0-beta.19

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.14
+version=1.0.0-beta.15

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.15
+version=1.0.0-beta.16

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.17
+version=1.0.0-beta.18


### PR DESCRIPTION
There is no more direct publishing to Maven, there is only ESRP. These were the same changes I'd made in Java, to remove the Maven publishing and the Sonatype ProfileIDs per GroupId from the scripts.

As part of these changes:

- I had to remove the mirror setting maven.publish.settings.xml, which was already removed from Java, because the mirror isn't working so well. 
- The EsrpRelease release task was still at version 1 which is really old and had to be upgraded to version 7. There was a slight SNAFU due to the one of the Inputs changing name.