### PR TITLE
Remove defunct parameter and use common template to create tags and git release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-android-release.yml
+++ b/eng/pipelines/templates/stages/archetype-android-release.yml
@@ -81,15 +81,14 @@ stages:
                 deploy:
                   steps:
                     - checkout: self
-                    - checkout: azure-sdk-build-tools
-                      path: azure-sdk-build-tools
-                    - pwsh: |
-                        $(Pipeline.Workspace)/azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 -artifactLocation $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.safeName}} -packageRepository Maven -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Name)
-                      displayName: 'Verify Package Tags and Create Git Releases'
-                      timeoutInMinutes: 5
-                      workingDirectory: $(Pipeline.Workspace)
-                      env:
-                        GH_TOKEN: $(azuresdk-github-pat)
+                    - download: current
+                      displayName: 'Download Artifact: ${{parameters.ArtifactName}}-signed'
+                      artifact: ${{parameters.ArtifactName}}-signed
+                    - template: /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+                      parameters:
+                        ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.safeName}}
+                        PackageRepository: Maven
+                        ReleaseSha: $(Build.SourceVersion)
 
           - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
@@ -126,7 +125,6 @@ stages:
                           ArtifactDirectory: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed
                           OutputDirectory: $(Pipeline.Workspace)/EsrpPackages
                           Target: EsrpRelease
-                          BuildToolsPath: $(Pipeline.Workspace)/azure-sdk-build-tools
                           # Note: In spite of the fact that the variable is named JavaRepoRoot, the
                           # root needs to be the root of the android repository
                           JavaRepoRoot: $(Pipeline.Workspace)/azure-sdk-for-android

--- a/sdk/template/azure-sdk-template/gradle.properties
+++ b/sdk/template/azure-sdk-template/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.0-beta.19
+version=1.0.0-beta.20


### PR DESCRIPTION
Remove defunct BuildToolsPath parameter being passed into the java-publishing.yml template.

The Android build was still using azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 instead of the using the /eng/common/pipelines/templates/steps/create-tags-and-git-release.yml template.

I [released template for Android](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3946735&view=results) and it sets the release tags just fine.