### PR TITLE
Update Gradle build task from 2 to 3

### DIFF
--- a/eng/common/pipelines/templates/steps/run-pester-tests.yml
+++ b/eng/common/pipelines/templates/steps/run-pester-tests.yml
@@ -49,10 +49,15 @@ steps:
       testResultsFiles: $(Build.SourcesDirectory)/${{ parameters.TargetDirectory }}/testResults.xml
       testRunTitle: $(System.StageName)_$(Agent.JobName)_Tests
 
+  # Dotnet core sdk task 7.0.x. Required for PublishCodeCoverageResults@2
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk 7.0.x'
+    inputs:
+      version: 7.0.x
+
   - task: PublishCodeCoverageResults@1
     displayName: Publish Code Coverage to Azure DevOps
     condition: succeededOrFailed()
     inputs:
-      codeCoverageTool: JaCoCo
       summaryFileLocation: $(Build.SourcesDirectory)/${{ parameters.TargetDirectory }}/coverage.xml
       pathToSources: $(Build.SourcesDirectory)/${{ parameters.TargetDirectory }}

--- a/eng/common/pipelines/templates/steps/run-pester-tests.yml
+++ b/eng/common/pipelines/templates/steps/run-pester-tests.yml
@@ -49,15 +49,10 @@ steps:
       testResultsFiles: $(Build.SourcesDirectory)/${{ parameters.TargetDirectory }}/testResults.xml
       testRunTitle: $(System.StageName)_$(Agent.JobName)_Tests
 
-  # Dotnet core sdk task 7.0.x. Required for PublishCodeCoverageResults@2
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core sdk 7.0.x'
-    inputs:
-      version: 7.0.x
-
   - task: PublishCodeCoverageResults@1
     displayName: Publish Code Coverage to Azure DevOps
     condition: succeededOrFailed()
     inputs:
+      codeCoverageTool: JaCoCo
       summaryFileLocation: $(Build.SourcesDirectory)/${{ parameters.TargetDirectory }}/coverage.xml
       pathToSources: $(Build.SourcesDirectory)/${{ parameters.TargetDirectory }}

--- a/eng/pipelines/aggregate-reports.yml
+++ b/eng/pipelines/aggregate-reports.yml
@@ -26,7 +26,7 @@ stages:
           vmImage: $(OSVmImage)
 
         steps:
-          - task: Gradle@2
+          - task: Gradle@3
             inputs:
               tasks: 'dependencies --write-locks'
               jdkVersion: $(JavaBuildVersion)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -14,7 +14,7 @@ jobs:
       os: linux
 
     steps:
-      - task: Gradle@2
+      - task: Gradle@3
         inputs:
           tasks: 'sdk:${{parameters.ServiceDirectory}}:publish'
           jdkVersion: $(JavaBuildVersion)
@@ -50,13 +50,13 @@ jobs:
           Directory: ''
           CheckLinkGuidance: $true
 
-      - task: Gradle@2
+      - task: Gradle@3
         inputs:
           tasks: 'sdk:${{parameters.ServiceDirectory}}:check'
           jdkVersion: $(JavaBuildVersion)
         displayName: Run code quality tools (lint, checkstyle and spotbug)
 
-      - task: Gradle@2
+      - task: Gradle@3
         inputs:
           tasks: 'sdk:${{parameters.ServiceDirectory}}:assembleDebug'
           jdkVersion: $(JavaBuildVersion)
@@ -101,7 +101,7 @@ jobs:
         parameters:
           AgentImage: $(OSVmImage)
 
-      - task: Gradle@2
+      - task: Gradle@3
         inputs:
           tasks: 'sdk:${{parameters.ServiceDirectory}}:jacocoTestReportDebug'
           jdkVersion: $(JavaTestVersion)

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -108,10 +108,15 @@ jobs:
           publishJUnitResults: true
         displayName: Build and test
 
+      # Dotnet core sdk task 7.0.x. Required for PublishCodeCoverageResults@2
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core sdk 7.0.x'
+        inputs:
+          version: 7.0.x
+
       - ${{ each artifact in parameters.Artifacts }}:
-        - task: PublishCodeCoverageResults@1
+        - task: PublishCodeCoverageResults@2
           inputs:
-            codeCoverageTool: 'JaCoCo'
             summaryFileLocation: 'sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/build/reports/jacoco/debug/jacoco.xml'
             pathToSources: 'sdk/${{parameters.ServiceDirectory}}/${{artifact.name}}/src/main/java/'
           displayName: Publish code coverage for ${{artifact.name}}


### PR DESCRIPTION
Two task version updates: 

- The Gradle@2 task is [deprecated](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4082805&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=e42dd2d1-9014-4902-9eb7-47ccde97e903&l=40) and needs to be updated to Gradle@3.
- The PublishCodeCoverageResults@1 task is deprecated and needs to be updated to [PublishCodeCoverageResults@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2?view=azure-pipelines). Unlike version 1, version 2 has a [prerequisite of dotnet core sdk task 7.0.x](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2?view=azure-pipelines#prerequisites) which also had to be added.

