### PR TITLE
Removing impression tracking pixels from READMEs ***NO_CI***

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-android%2FREADME.png)
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,4 +4,4 @@ This directory contains some documentations for this repository:
 The directory structure is the following
 - [design](https://github.com/Azure/azure-sdk-for-android/blob/main/doc/design) : contains design documentation for _developers_ of SDK (not _consumers_ of SDK)
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-android%2Fdoc%2FREADME.png)
+

--- a/eng/code-quality-reports/README.md
+++ b/eng/code-quality-reports/README.md
@@ -3,4 +3,4 @@
 This module defines/configures the rules for code quality analysis tools such as checkstyle and spotbugs.
 For more information refer to [Checkstyle](https://checkstyle.org/) and [Spotbugs](https://spotbugs.github.io/).
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-android%2Feng%2Fcode-quality-reports%2FREADME.png)
+

--- a/sdk/communication/azure-communication-common/README.md
+++ b/sdk/communication/azure-communication-common/README.md
@@ -166,4 +166,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
 [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-android%2Fsdk%2Fcommunication%2Fazure-communication-common%2FREADME.png)
+

--- a/sdk/core/azure-core-credential/README.md
+++ b/sdk/core/azure-core-credential/README.md
@@ -45,4 +45,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-http-httpurlconnection/README.md
+++ b/sdk/core/azure-core-http-httpurlconnection/README.md
@@ -50,4 +50,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-http-okhttp/README.md
+++ b/sdk/core/azure-core-http-okhttp/README.md
@@ -50,4 +50,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-http/README.md
+++ b/sdk/core/azure-core-http/README.md
@@ -54,4 +54,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-jackson/README.md
+++ b/sdk/core/azure-core-jackson/README.md
@@ -54,4 +54,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-logging/README.md
+++ b/sdk/core/azure-core-logging/README.md
@@ -54,4 +54,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-rest/README.md
+++ b/sdk/core/azure-core-rest/README.md
@@ -52,4 +52,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core-test/README.md
+++ b/sdk/core/azure-core-test/README.md
@@ -123,4 +123,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+

--- a/sdk/core/azure-core/README.md
+++ b/sdk/core/azure-core/README.md
@@ -52,4 +52,4 @@ If you would like to become an active contributor to this project please follow 
 [logging]: https://github.com/Azure/azure-sdk-for-java/wiki/Logging-with-Azure-SDK
 [jdk_link]: https://docs.microsoft.com/java/azure/jdk/?view=azure-java-stable
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fcore%2Fazure-core%2FREADME.png)
+


### PR DESCRIPTION
# Description
Pixels like these were used to track impressions on READMEs, deleteing them in accordance to latest policy

```markdown
![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-java%2Fsdk%2Fsearch%2FCONTRIBUTING.png)
```
