### PR TITLE
Add CredScanSuppression.json

### DIFF
--- a/eng/CredScanSuppression.json
+++ b/eng/CredScanSuppression.json
@@ -1,0 +1,11 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": [
+                "eng/common/testproxy/dotnet-devcert.pfx"
+            ],
+            "_justification": "File contains private key used by test code."
+        }
+    ]
+}


### PR DESCRIPTION
This needs to be added separately from download-credscan-suppressions.yml, which uses it, because if it's not in main already, the step will fail.