### PR TITLE
Update Maven package URI to use Maven Central

### DIFF
--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -55,7 +55,10 @@ function SetPackageVersion ($PackageName, $Version, $ReleaseDate, $ReplaceLatest
 # Returns the maven (really sonatype) publish status of a package id and version.
 function IsMavenPackageVersionPublished($pkgId, $pkgVersion, $groupId)
 {
-  $uri = "https://oss.sonatype.org/content/repositories/releases/$($groupId.Replace('.', '/'))/$pkgId/$pkgVersion/$pkgId-$pkgVersion.pom"
+  # oss.sonatype.org seems to have started returning 403 for our agents. Based on https://central.sonatype.org/faq/403-error-central it is likely
+  # because some agent is trying to query the directory too frequently. So we will attempt to query the raw maven repo itself.
+  # $uri = "https://oss.sonatype.org/content/repositories/releases/$($groupId.Replace('.', '/'))/$pkgId/$pkgVersion/$pkgId-$pkgVersion.pom"
+  $uri = "https://repo1.maven.org/maven2/$($groupId.Replace('.', '/'))/$pkgId/$pkgVersion/$pkgId-$pkgVersion.pom"
 
   $attempt = 1
   while ($attempt -le 3)


### PR DESCRIPTION
Based on [the code](https://github.com/Azure/azure-sdk-for-java/blob/5d1c49b93a3d948247edd943166c76be0c47b666/eng/scripts/Language-Settings.ps1#L283) in Java repo, change the Maven package version check URI to use Maven Central.