### PR TITLE
Remove `core` path filters from triggers

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -7,13 +7,6 @@ trigger:
       - feature/*
       - hotfix/*
       - release/*
-  paths:
-    include:
-      - sdk/core/
-      - eng/
-      - build.gradle
-      - gradle.properties
-      - settings.gradle
 
 pr:
   branches:
@@ -22,13 +15,6 @@ pr:
       - feature/*
       - hotfix/*
       - release/*
-  paths:
-    include:
-      - sdk/core/
-      - eng/
-      - build.gradle
-      - gradle.properties
-      - settings.gradle
 
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
So that triggers in all cases. Related to Azure/azure-sdk-tools#15160