### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -7,3 +7,4 @@ extends:
   template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
   parameters:
     Repository: Azure/azure-sdk-for-android
+    AuthToken: ''

--- a/eng/pipelines/prepare-pipelines.yml
+++ b/eng/pipelines/prepare-pipelines.yml
@@ -7,4 +7,3 @@ extends:
   template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
   parameters:
     Repository: Azure/azure-sdk-for-android
-    AuthToken: ''

--- a/eng/pipelines/templates/stages/archetype-android-release.yml
+++ b/eng/pipelines/templates/stages/archetype-android-release.yml
@@ -126,6 +126,7 @@ stages:
                   ArtifactLocation: $(Pipeline.Workspace)/${{parameters.ArtifactName}}-signed/${{artifact.safeName}}
                   PackageRepository: Maven
                   ReleaseSha: $(Build.SourceVersion)
+                  AuthToken: ''
 
           - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
             - deployment: PublishESRPPackage


### PR DESCRIPTION
This pull request introduces minor configuration changes to the Azure pipeline YAML files. The main update is the explicit addition of an empty `AuthToken` parameter in two locations, likely to ensure consistent parameterization or to override a default value.

Most important changes:

**Pipeline configuration updates:**

* Added an explicit `AuthToken: ''` parameter to the `prepare-pipelines.yml` pipeline template to ensure the parameter is set, even if empty.
* Set `AuthToken: ''` in the `archetype-android-release.yml` release stage, likely to standardize authentication settings or prevent accidental token usage.

Related to Azure/azure-sdk-tools#9842